### PR TITLE
Add dataset path setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ python manage.py runserver
 
 Navigate to `http://localhost:8000/` to search for a movie and view
 recommendations.
+
+The web app looks for the reduced dataset using the `RECOMMENDER_DATASET_PATH`
+setting in `webapp/webapp/settings.py`. By default it points to
+`movies_10.csv` in the project root. Update this path if your CSV is stored
+elsewhere.

--- a/webapp/movies/views.py
+++ b/webapp/movies/views.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 
+from django.conf import settings
+
 from django.shortcuts import render
 
 from src.movie_recommender import MovieRecommender
 
 recommender = MovieRecommender()
-BASE_DIR = Path(__file__).resolve().parents[2]
-DATASET_PATH = BASE_DIR / "movies_10.csv"
+DATASET_PATH = Path(settings.RECOMMENDER_DATASET_PATH)
 
 
 def search(request):

--- a/webapp/webapp/settings.py
+++ b/webapp/webapp/settings.py
@@ -121,3 +121,6 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Location of the reduced movie dataset used by the recommender
+RECOMMENDER_DATASET_PATH = BASE_DIR / "movies_10.csv"


### PR DESCRIPTION
## Summary
- configure dataset path via `RECOMMENDER_DATASET_PATH` in Django settings
- use that setting in the movie search view instead of a hard-coded path
- document the new setting in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc69910a48332ab575b6ec5d3da40