### PR TITLE
Cache MovieRecommender in view

### DIFF
--- a/webapp/movies/test_views.py
+++ b/webapp/movies/test_views.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if BASE_DIR not in sys.path:
+    sys.path.insert(0, BASE_DIR)
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "webapp.settings")
+import django
+django.setup()
+
+import pandas as pd
+from django.test import SimpleTestCase, override_settings
+
+from movies.views import get_recommender, _load_recommender
+
+
+class GetRecommenderTest(SimpleTestCase):
+    """Tests for the cached recommender helper."""
+
+    def setUp(self):
+        _load_recommender.cache_clear()
+
+    def test_dataset_loaded_once(self):
+        df = pd.DataFrame(
+            {
+                "title": ["Movie A"],
+                "director": ["Director A"],
+                "genres": ["Drama"],
+                "score": [9.0],
+                "actors": ["Actor X"],
+            }
+        )
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False, mode="w+") as tmp:
+            df.to_csv(tmp.name, index=False)
+        try:
+            with override_settings(RECOMMENDER_DATASET_PATH=tmp.name):
+                with patch("src.movie_recommender.MovieRecommender.load_dataset") as mock_load:
+                    mock_load.return_value = df
+                    rec1 = get_recommender()
+                    rec2 = get_recommender()
+            self.assertIs(rec1, rec2)
+            mock_load.assert_called_once_with(tmp.name)
+        finally:
+            os.unlink(tmp.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webapp/movies/views.py
+++ b/webapp/movies/views.py
@@ -1,13 +1,28 @@
+"""Views for the movie recommendation app."""
+
+from functools import lru_cache
 from pathlib import Path
 
 from django.conf import settings
-
 from django.shortcuts import render
 
 from src.movie_recommender import MovieRecommender
 
-recommender = MovieRecommender()
-DATASET_PATH = Path(settings.RECOMMENDER_DATASET_PATH)
+
+@lru_cache(maxsize=1)
+def _load_recommender(dataset: str) -> MovieRecommender:
+    """Return a recommender with ``dataset`` loaded."""
+    recommender = MovieRecommender()
+    recommender.load_dataset(dataset)
+    return recommender
+
+
+def get_recommender() -> MovieRecommender:
+    """Return a cached :class:`MovieRecommender` instance."""
+    dataset_path = Path(settings.RECOMMENDER_DATASET_PATH)
+    if not dataset_path.exists():
+        raise ValueError("Dataset not found. Please run dataset reducer.")
+    return _load_recommender(str(dataset_path))
 
 
 def search(request):
@@ -18,13 +33,7 @@ def search(request):
         title = request.POST.get("title", "")
         if title:
             try:
-                if recommender.df is None:
-                    if DATASET_PATH.exists():
-                        recommender.load_dataset(DATASET_PATH)
-                    else:
-                        raise ValueError(
-                            "Dataset not found. Please run dataset reducer."
-                        )
+                recommender = get_recommender()
                 recommendations = recommender.recommend(title)
             except Exception as exc:
                 error = str(exc)


### PR DESCRIPTION
## Summary
- load `MovieRecommender` lazily using an LRU cached helper
- adjust view to get recommender via helper
- add tests for the caching behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc76c0d048332920ffa018b4c65e5