### PR TITLE
Add AI-native workflow commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 # Virtual environments
 venv/
 .venv/
+.uv-cache/
 
 # Django database
 webapp/db.sqlite3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,10 +139,12 @@ Good near-term improvements are usually boring and valuable: stable movie IDs, b
 - Use GitHub Issues/Projects as the source of truth for roadmap and implementation tasks.
 - `Roadmap` means discussion/scoping/tradeoffs.
 - `Codex Ready` plus the `codex-ready` label means scoped, accepted, and verifiable.
-- Expected loop: GitHub issue to Codex implementation to `make test` output to PR to Juno review to project state update.
+- Expected loop: GitHub issue to local Codex implementation to `make test` output to PR to Juno review to project state update.
+- Prefer a temporary full clone for local Codex implementation work; clean it up after the PR merges or closes.
+- Use GitHub `@codex` for automated PR review and review-feedback follow-ups on the existing PR branch.
 - Codex may create PRs for review, but only after the canonical tests actually run and pass.
 - If tests cannot run because dependencies, network, data, or tooling are unavailable, stop and report the blocker instead of creating a review-ready PR.
-- Move implemented work to `Review`; completed work to `Done`.
+- Move implemented work to `Review`; completed work to `Manual E2E` when Ramon needs to test app behavior, or to `Done` when fully verified.
 
 When pushing changes or creating a PR, include:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,10 +139,12 @@ Good near-term improvements are usually boring and valuable: stable movie IDs, b
 - Use GitHub Issues/Projects as the source of truth for roadmap and implementation tasks.
 - `Roadmap` means discussion/scoping/tradeoffs.
 - `Codex Ready` plus the `codex-ready` label means scoped, accepted, and verifiable.
-- Expected loop: GitHub issue to Codex implementation to `make test` output to Juno review to PR/project state update.
+- Expected loop: GitHub issue to Codex implementation to `make test` output to PR to Juno review to project state update.
+- Codex may create PRs for review, but only after the canonical tests actually run and pass.
+- If tests cannot run because dependencies, network, data, or tooling are unavailable, stop and report the blocker instead of creating a review-ready PR.
 - Move implemented work to `Review`; completed work to `Done`.
 
-When pushing changes, include:
+When pushing changes or creating a PR, include:
 
 - Summary of changed files.
 - Exact verification command(s) and real output, especially `make test`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,19 @@ Use Python 3.11+.
 Prefer a virtual environment. On this host, `uv` is available and is the least-annoying route:
 
 ```bash
-uv venv
-source .venv/bin/activate
-uv pip install -r requirements.txt
+make setup
 ```
+
+`make setup` creates `.venv` with `uv` when available, otherwise it installs
+`requirements.txt` into the active Python environment. If `make` is unavailable,
+run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv venv --allow-existing
+UV_CACHE_DIR=.uv-cache uv pip install --python .venv/bin/python -r requirements.txt
+```
+
+Without `uv`, run `python -m pip install -r requirements.txt`.
 
 The older `venv/` directory name and the common `.venv/` directory are both ignored. Do not commit virtualenvs, generated CSVs, caches, or local databases.
 
@@ -63,11 +72,16 @@ python recommender.py movies_10.csv "Inception"
 Run the Django app:
 
 ```bash
-cd webapp
-python manage.py runserver
+make run-web
 ```
 
 The web app reads `RECOMMENDER_DATASET_PATH` from `webapp/webapp/settings.py`; by default it expects `movies_10.csv` in the repo root.
+
+Run a lightweight Django configuration check:
+
+```bash
+make smoke
+```
 
 ## Tests and verification
 
@@ -80,8 +94,11 @@ There are tests. Not many, but enough to be offended if ignored:
 Run from the repo root after installing dependencies:
 
 ```bash
-python -m pytest -q
+make test
 ```
+
+`make test` is the canonical test command for agent reports. It runs
+`python -m pytest -q`.
 
 You can also run Django tests directly:
 
@@ -122,10 +139,12 @@ Good near-term improvements are usually boring and valuable: stable movie IDs, b
 - Use GitHub Issues/Projects as the source of truth for roadmap and implementation tasks.
 - `Roadmap` means discussion/scoping/tradeoffs.
 - `Codex Ready` plus the `codex-ready` label means scoped, accepted, and verifiable.
+- Expected loop: GitHub issue to Codex implementation to `make test` output to Juno review to PR/project state update.
 - Move implemented work to `Review`; completed work to `Done`.
 
 When pushing changes, include:
 
 - Summary of changed files.
-- Exact verification command(s) and real output.
+- Exact verification command(s) and real output, especially `make test`.
 - Any known blocker, especially missing dependencies or unavailable data.
+- Next suggested issue or review step when it is clear from the current work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Run the Django app:
 make run-web
 ```
 
-The web app reads `RECOMMENDER_DATASET_PATH` from `webapp/webapp/settings.py`; by default it expects `movies_10.csv` in the repo root.
+The web app reads `RECOMMENDER_DATASET_PATH` from `webapp/webapp/settings.py`; by default it expects `webapp/movies_10.csv`.
 
 Run a lightweight Django configuration check:
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+PYTHON ?= $(if $(wildcard .venv/bin/python),.venv/bin/python,python)
+UV_CACHE_DIR ?= .uv-cache
+
+.PHONY: help setup test run-web smoke
+
+help:
+	@echo "MovieRecommender commands:"
+	@echo "  make setup    Create/use .venv and install Python dependencies"
+	@echo "  make test     Run the pytest suite"
+	@echo "  make run-web  Start the Django development server"
+	@echo "  make smoke    Run Django's lightweight project check"
+
+setup:
+	@if command -v uv >/dev/null 2>&1; then \
+		UV_CACHE_DIR=$(UV_CACHE_DIR) uv venv --allow-existing && \
+		UV_CACHE_DIR=$(UV_CACHE_DIR) uv pip install --python .venv/bin/python -r requirements.txt; \
+	else \
+		$(PYTHON) -m pip install -r requirements.txt; \
+	fi
+
+test:
+	$(PYTHON) -m pytest -q
+
+run-web:
+	$(PYTHON) webapp/manage.py runserver
+
+smoke:
+	$(PYTHON) webapp/manage.py check

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Run the current Django app:
 make run-web
 ```
 
-The web app expects a reduced dataset at `movies_10.csv` in the project root
-unless `RECOMMENDER_DATASET_PATH` is changed in `webapp/webapp/settings.py`.
+The web app expects a reduced dataset at `webapp/movies_10.csv` unless
+`RECOMMENDER_DATASET_PATH` is changed in `webapp/webapp/settings.py`.
 
 ## AI-Agent Workflow
 
@@ -92,5 +92,4 @@ recommendations.
 
 The web app looks for the reduced dataset using the `RECOMMENDER_DATASET_PATH`
 setting in `webapp/webapp/settings.py`. By default it points to
-`movies_10.csv` in the project root. Update this path if your CSV is stored
-elsewhere.
+`webapp/movies_10.csv`. Update this path if your CSV is stored elsewhere.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,48 @@ Since the dataset is so big, `movies.py` is first used to reduce the data using 
 
 Both scripts now rely on the `MovieDatasetReducer` and `MovieRecommender` classes located in the `src` package.
 
+## Quickstart
+
+Use Python 3.11+ from the repository root. `make setup` creates `.venv` with
+`uv` when available, otherwise it installs into the active Python environment:
+
+```bash
+make setup
+```
+
+Run the canonical test suite:
+
+```bash
+make test
+```
+
+Run a lightweight Django configuration check:
+
+```bash
+make smoke
+```
+
+Run the current Django app:
+
+```bash
+make run-web
+```
+
+The web app expects a reduced dataset at `movies_10.csv` in the project root
+unless `RECOMMENDER_DATASET_PATH` is changed in `webapp/webapp/settings.py`.
+
+## AI-Agent Workflow
+
+Use GitHub issues as the source of truth for scoped changes. The expected loop
+is:
+
+1. Read `AGENTS.md`, the issue body, and relevant local code before editing.
+2. Implement only the accepted issue scope.
+3. Run `make test` from the repository root and capture the real output.
+4. Report changed files, verification command output, known blockers, and the
+   next suggested issue or review step.
+5. Hand off for Juno review, then GitHub PR/project state updates.
+
 `Examples:`
 
 | The Dark Knight  | Se7en | The Departed |
@@ -37,11 +79,10 @@ Data location: https://datasets.imdbws.com/
 ### Web App
 
 After generating a reduced dataset (`movies_10.csv` by default), you can start
-the Django development server from the `webapp` directory:
+the Django development server from the repository root:
 
 ```bash
-cd webapp
-python manage.py runserver
+make run-web
 ```
 
 Navigate to `http://localhost:8000/` to search for a movie and view

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ is:
 1. Read `AGENTS.md`, the issue body, and relevant local code before editing.
 2. Implement only the accepted issue scope.
 3. Run `make test` from the repository root and capture the real output.
-4. Report changed files, verification command output, known blockers, and the
-   next suggested issue or review step.
-5. Hand off for Juno review, then GitHub PR/project state updates.
+4. If tests pass, create a PR ready for Juno review with changed files,
+   verification command output, blockers, and the next suggested issue or review
+   step.
+5. If tests cannot run or fail, do not create a review-ready PR; report the
+   blocker and stop for Juno intervention.
 
 `Examples:`
 


### PR DESCRIPTION
## Summary
- Adds a repo-level Makefile with setup, test, run-web, smoke, and help targets.
- Documents the AI-native issue → Codex implementation → test output → Juno review loop.
- Updates README/AGENTS to make setup/test/run commands discoverable from tracked files.

## Verification
- `make setup && make test` → `6 passed in 7.25s`
- `make smoke` → `System check identified no issues (0 silenced).`

Closes #22