### PR TITLE
Add canonical IMDb reducer baseline

### DIFF
--- a/movies.py
+++ b/movies.py
@@ -19,12 +19,18 @@ def main():
     parser.add_argument(
         "-o", "--output", default="movies_10", help="Output filename without extension"
     )
+    parser.add_argument(
+        "--min-votes",
+        type=int,
+        default=1000,
+        help="Minimum votes to keep; use 0 to rely only on --percentage",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     reducer = MovieDatasetReducer()
-    reducer.reduce_dataset(args.percentage, args.output)
+    reducer.reduce_dataset(args.percentage, args.output, min_votes=args.min_votes)
 
 
 if __name__ == "__main__":

--- a/src/dataset_reducer.py
+++ b/src/dataset_reducer.py
@@ -120,6 +120,18 @@ class MovieDatasetReducer:
             .reset_index()
         )
 
+    @staticmethod
+    def disambiguate_duplicate_titles(metadata: pd.DataFrame) -> pd.DataFrame:
+        """Append IMDb IDs to duplicate titles while preserving primary titles."""
+        metadata = metadata.copy()
+        metadata["primary_title"] = metadata["primaryTitle"]
+        metadata["title"] = metadata["primaryTitle"]
+        duplicate_titles = metadata["title"].duplicated(keep=False)
+        metadata.loc[duplicate_titles, "title"] = metadata.loc[
+            duplicate_titles
+        ].apply(lambda row: f"{row['primary_title']} ({row['tconst']})", axis=1)
+        return metadata
+
     def build_reduced_dataset(
         self,
         titles: pd.DataFrame,
@@ -150,11 +162,12 @@ class MovieDatasetReducer:
         metadata["director"] = metadata["director_names"].apply(
             lambda values: values[0] if values else ""
         )
-        metadata.rename(columns={"primaryTitle": "title"}, inplace=True)
+        metadata = self.disambiguate_duplicate_titles(metadata)
 
         columns = [
             "tconst",
             "title",
+            "primary_title",
             "director",
             "director_ids",
             "director_names",

--- a/src/dataset_reducer.py
+++ b/src/dataset_reducer.py
@@ -14,6 +14,10 @@ logger = logging.getLogger(__name__)
 class MovieDatasetReducer:
     """Reduce raw IMDb TSV dumps to a smaller CSV dataset."""
 
+    DIRECTOR_LIMIT = 3
+    CAST_LIMIT = 5
+    DEFAULT_MIN_VOTES = 1000
+
     @staticmethod
     def weighted_rating(row: pd.Series, C: float, m: float) -> float:
         """Compute IMDb weighted rating for a single row."""
@@ -21,8 +25,168 @@ class MovieDatasetReducer:
         R = row["averageRating"]
         return (v / (v + m) * R) + (m / (m + v) * C)
 
+    @staticmethod
+    def split_imdb_ids(value: object, limit: int | None = None) -> list[str]:
+        """Split comma-separated IMDb identifier fields."""
+        if pd.isna(value) or value == r"\N":
+            return []
+        ids = [item for item in str(value).split(",") if item and item != r"\N"]
+        if limit is None:
+            return ids
+        return ids[:limit]
+
+    @staticmethod
+    def split_genres(value: object) -> list[str]:
+        """Split IMDb genre strings into a typed list."""
+        return MovieDatasetReducer.split_imdb_ids(value)
+
+    @staticmethod
+    def _read_tsv(
+        path: str,
+        usecols: list[str],
+        chunksize: int | None = 1000000,
+    ) -> pd.DataFrame:
+        """Read an IMDb TSV, preserving the existing chunked path for large files."""
+        reader = pd.read_csv(
+            path,
+            low_memory=False,
+            chunksize=chunksize,
+            sep="\t",
+            encoding="utf-8",
+            usecols=usecols,
+        )
+        if chunksize is None:
+            return reader
+        return pd.concat(reader)
+
+    def _apply_vote_filter(
+        self,
+        metadata: pd.DataFrame,
+        percentage: float | None,
+        min_votes: int | None,
+    ) -> pd.DataFrame:
+        """Filter by the quantile path and/or the explicit minimum-votes path."""
+        C = metadata["averageRating"].mean()
+        thresholds = []
+        if percentage is not None:
+            thresholds.append(metadata["numVotes"].quantile(percentage))
+        if min_votes is not None:
+            thresholds.append(min_votes)
+
+        m = max(thresholds) if thresholds else 0
+        metadata = metadata.loc[metadata["numVotes"] >= m].copy()
+        metadata["score"] = metadata.apply(self.weighted_rating, C=C, m=m, axis=1)
+        return metadata
+
+    def _director_lists(
+        self, crew: pd.DataFrame, names: pd.DataFrame
+    ) -> pd.DataFrame:
+        """Return top director IDs and names per title in IMDb order."""
+        directors = crew[["tconst", "directors"]].copy()
+        directors["director_ids"] = directors["directors"].apply(
+            lambda value: self.split_imdb_ids(value, self.DIRECTOR_LIMIT)
+        )
+        directors = directors[["tconst", "director_ids"]].explode("director_ids")
+        directors = directors.dropna(subset=["director_ids"])
+        directors["position"] = directors.groupby("tconst").cumcount()
+        directors = directors.merge(
+            names, how="left", left_on="director_ids", right_on="nconst"
+        )
+        directors = directors.sort_values(["tconst", "position"])
+        return (
+            directors.groupby("tconst", sort=False)
+            .agg(
+                director_ids=("director_ids", list),
+                director_names=("primaryName", list),
+            )
+            .reset_index()
+        )
+
+    def _cast_lists(self, principals: pd.DataFrame, names: pd.DataFrame) -> pd.DataFrame:
+        """Return top actor/actress IDs and names per title in principal order."""
+        cast = principals.loc[
+            principals["category"].isin(["actor", "actress"])
+        ].copy()
+        if "ordering" in cast.columns:
+            cast = cast.sort_values(["tconst", "ordering"])
+        cast = cast.groupby("tconst", group_keys=False).head(self.CAST_LIMIT)
+        cast = cast.merge(names, how="left", on="nconst")
+        return (
+            cast.groupby("tconst", sort=False)
+            .agg(
+                cast_ids=("nconst", list),
+                actors=("primaryName", list),
+            )
+            .reset_index()
+        )
+
+    def build_reduced_dataset(
+        self,
+        titles: pd.DataFrame,
+        crew: pd.DataFrame,
+        ratings: pd.DataFrame,
+        names: pd.DataFrame,
+        principals: pd.DataFrame,
+        percentage: float | None = 0.90,
+        min_votes: int | None = DEFAULT_MIN_VOTES,
+    ) -> pd.DataFrame:
+        """Build a typed reduced dataset from IMDb source DataFrames."""
+        metadata = titles.loc[titles["titleType"] == "movie"].copy()
+        metadata = metadata.merge(ratings, on="tconst")
+        metadata = metadata.merge(crew[["tconst", "directors"]], on="tconst")
+
+        metadata = self._apply_vote_filter(metadata, percentage, min_votes)
+        metadata["genres"] = metadata["genres"].apply(self.split_genres)
+
+        directors = self._director_lists(crew, names)
+        cast = self._cast_lists(principals, names)
+        metadata = metadata.merge(directors, how="left", on="tconst")
+        metadata = metadata.merge(cast, how="left", on="tconst")
+
+        for column in ["director_ids", "director_names", "cast_ids", "actors"]:
+            metadata[column] = metadata[column].apply(
+                lambda value: value if isinstance(value, list) else []
+            )
+        metadata["director"] = metadata["director_names"].apply(
+            lambda values: values[0] if values else ""
+        )
+        metadata.rename(columns={"primaryTitle": "title"}, inplace=True)
+
+        columns = [
+            "tconst",
+            "title",
+            "director",
+            "director_ids",
+            "director_names",
+            "genres",
+            "score",
+            "cast_ids",
+            "actors",
+        ]
+        return (
+            metadata[columns]
+            .sort_values("score", ascending=False)
+            .reset_index(drop=True)
+        )
+
+    def _write_typed_output(
+        self, metadata: pd.DataFrame, output_name: str | Path
+    ) -> None:
+        """Write a typed artifact when pandas has Parquet engine support."""
+        output_path = Path(f"{output_name}.parquet")
+        try:
+            metadata.to_parquet(output_path, index=False)
+        except (ImportError, ValueError) as exc:
+            logger.info("Skipped typed Parquet output: %s", exc)
+            return
+        logger.info("Saved typed dataset to %s", output_path)
+
     def reduce_dataset(
-        self, percentage: float, output_name: str | Path
+        self,
+        percentage: float | None,
+        output_name: str | Path,
+        min_votes: int | None = DEFAULT_MIN_VOTES,
+        write_typed: bool = True,
     ) -> pd.DataFrame:
         """Reduce the raw IMDb dump.
 
@@ -33,97 +197,50 @@ class MovieDatasetReducer:
             10%% of movies by vote count.
         output_name:
             Path prefix for the CSV file that will be written.
+        min_votes:
+            Explicit vote threshold to retain. ``None`` disables this path.
+            When both percentage and min_votes are provided, the stricter
+            threshold is used.
+        write_typed:
+            Write a Parquet artifact next to the CSV when optional pandas
+            dependencies support it.
         """
         logger.info("Getting movie dataset...")
-        title = pd.read_csv(
+        title = self._read_tsv(
             "title.basics.tsv",
-            low_memory=False,
-            chunksize=1000000,
-            sep="\t",
-            encoding="utf-8",
-            usecols=["tconst", "titleType", "primaryTitle", "genres"],
+            ["tconst", "titleType", "primaryTitle", "genres"],
         )
-        director = pd.read_csv(
-            "title.crew.tsv",
-            low_memory=False,
-            chunksize=1000000,
-            sep="\t",
-            encoding="utf-8",
-            usecols=["tconst", "directors"],
-        )
+        director = self._read_tsv("title.crew.tsv", ["tconst", "directors"])
         ratings = pd.read_csv("title.ratings.tsv", sep="\t", encoding="utf-8")
 
-        metadata = pd.concat(title)
-        director = pd.concat(director)
-        metadata = metadata.loc[metadata["titleType"] == "movie"]
-
-        metadata = metadata.merge(ratings, on="tconst")
-        metadata = metadata.merge(director, on="tconst")
-        title, ratings, director = None, None, None
-
-        metadata["directors"] = metadata["directors"].apply(lambda x: x[:9])
-
         logger.info(
-            "Reducing data to %s%% of most popular movies.",
-            round((1 - percentage) * 100),
+            "Reducing data to %s%% of most popular movies with at least %s votes.",
+            round((1 - percentage) * 100) if percentage is not None else "all",
+            min_votes,
         )
-        C = metadata["averageRating"].mean()
-        m = metadata["numVotes"].quantile(percentage)
-        metadata = metadata.loc[metadata["numVotes"] >= m]
-        metadata["score"] = metadata.apply(self.weighted_rating, C=C, m=m, axis=1)
 
         logger.info("Getting movie directors...")
-        names = pd.read_csv(
-            "name.basics.tsv",
-            low_memory=False,
-            chunksize=1000000,
-            sep="\t",
-            encoding="utf-8",
-            usecols=["nconst", "primaryName"],
-        )
-        names = pd.concat(names)
-        metadata = metadata.merge(
-            names, how="left", left_on="directors", right_on="nconst"
-        )
-
-        series = ["directors", "nconst", "averageRating", "numVotes"]
-        for column in series:
-            del metadata[column]
-
-        metadata.rename(columns={"primaryName": "director"}, inplace=True)
+        names = self._read_tsv("name.basics.tsv", ["nconst", "primaryName"])
 
         logger.info("Getting movie cast members...")
-        cast = pd.read_csv(
+        cast = self._read_tsv(
             "title.principals.tsv",
-            low_memory=False,
-            chunksize=1000000,
-            sep="\t",
-            encoding="utf-8",
-            usecols=["tconst", "nconst", "category"],
-        )
-        cast = pd.concat(cast)
-        cast = cast.loc[cast["category"] == "actor"]
-        metadata = metadata.merge(cast, how="left", on="tconst")
-        metadata = metadata.merge(names, how="left", on="nconst")
-        cast, names = None, None
-
-        metadata.rename(columns={"primaryName": "actors"}, inplace=True)
-        metadata.rename(columns={"primaryTitle": "title"}, inplace=True)
-
-        metadata = (
-            metadata.astype(str)
-            .groupby(["title", "director", "genres", "score"])["actors"]
-            .apply(list)
-            .reset_index()
+            ["tconst", "ordering", "nconst", "category"],
         )
 
-        metadata["genres"] = (
-            metadata["genres"].astype(str).apply(lambda x: x.split(","))
+        metadata = self.build_reduced_dataset(
+            title,
+            director,
+            ratings,
+            names,
+            cast,
+            percentage=percentage,
+            min_votes=min_votes,
         )
-
-        metadata = metadata.sort_values("score", ascending=False)
 
         output_path = Path(f"{output_name}.csv")
         metadata.to_csv(output_path)
         logger.info("Saved dataset to %s", output_path)
+        if write_typed:
+            self._write_typed_output(metadata, output_name)
         return metadata

--- a/src/movie_recommender.py
+++ b/src/movie_recommender.py
@@ -11,6 +11,8 @@ from sklearn.metrics.pairwise import cosine_similarity
 class MovieRecommender:
     """Load movie data and generate recommendations."""
 
+    REQUIRED_COLUMNS = {"title", "director", "genres", "score", "actors"}
+
     def __init__(self):
         self.df = None
         self.indices = None
@@ -32,14 +34,36 @@ class MovieRecommender:
             ["".join(row["actors"]), "".join(row["director"]), "".join(row["genres"])]
         )
 
+    @staticmethod
+    def _disambiguate_duplicate_titles(df: pd.DataFrame) -> pd.DataFrame:
+        """Use tconst suffixes when duplicate title rows would break lookup."""
+        if "tconst" not in df.columns or not df["title"].duplicated(keep=False).any():
+            return df
+
+        df = df.copy()
+        duplicate_titles = df["title"].duplicated(keep=False)
+        df.loc[duplicate_titles, "title"] = df.loc[duplicate_titles].apply(
+            lambda row: f"{row['title']} ({row['tconst']})", axis=1
+        )
+        return df
+
     def load_dataset(self, dataset: str | Path) -> pd.DataFrame:
         """Read the reduced CSV dataset and prepare similarity matrix."""
-        df = pd.read_csv(
-            dataset,
-            sep=",",
-            encoding="utf-8",
-            usecols=["title", "director", "genres", "score", "actors"],
-        )
+        df = pd.read_csv(dataset, sep=",", encoding="utf-8")
+        missing_columns = sorted(self.REQUIRED_COLUMNS - set(df.columns))
+        if missing_columns:
+            raise ValueError(
+                "Dataset is missing required column(s): " + ", ".join(missing_columns)
+            )
+
+        df = self._disambiguate_duplicate_titles(df)
+        if df["title"].duplicated().any():
+            raise ValueError(
+                "Dataset contains duplicate title values and no tconst values to "
+                "disambiguate them."
+            )
+
+        df = df[["title", "director", "genres", "score", "actors"]].copy()
         df["director"] = df["director"].apply(lambda x: [x, x])
         for column in ["actors", "genres", "director"]:
             df[column] = df[column].astype("str").apply(self.clean_data)

--- a/webapp/movies/test_movies.py
+++ b/webapp/movies/test_movies.py
@@ -21,6 +21,174 @@ class MovieUtilsTest(unittest.TestCase):
         rating = reducer.weighted_rating(row, C=7.0, m=50)
         self.assertAlmostEqual(rating, 7.6667, places=4)
 
+    def test_build_reduced_dataset_preserves_duplicate_titles_by_tconst(self) -> None:
+        """Movies sharing a title should remain distinct canonical rows."""
+        reducer = MovieDatasetReducer()
+        dataset = reducer.build_reduced_dataset(
+            titles=pd.DataFrame(
+                {
+                    "tconst": ["tt001", "tt002"],
+                    "titleType": ["movie", "movie"],
+                    "primaryTitle": ["Same Title", "Same Title"],
+                    "genres": ["Drama", "Comedy"],
+                }
+            ),
+            crew=pd.DataFrame(
+                {
+                    "tconst": ["tt001", "tt002"],
+                    "directors": ["nm001", "nm002"],
+                }
+            ),
+            ratings=pd.DataFrame(
+                {
+                    "tconst": ["tt001", "tt002"],
+                    "averageRating": [7.0, 8.0],
+                    "numVotes": [10, 20],
+                }
+            ),
+            names=pd.DataFrame(
+                {
+                    "nconst": ["nm001", "nm002", "nm101", "nm102"],
+                    "primaryName": [
+                        "Director One",
+                        "Director Two",
+                        "Actor One",
+                        "Actor Two",
+                    ],
+                }
+            ),
+            principals=pd.DataFrame(
+                {
+                    "tconst": ["tt001", "tt002"],
+                    "ordering": [1, 1],
+                    "nconst": ["nm101", "nm102"],
+                    "category": ["actor", "actor"],
+                }
+            ),
+            percentage=None,
+            min_votes=0,
+        )
+
+        self.assertEqual(set(dataset["tconst"]), {"tt001", "tt002"})
+        self.assertEqual(dataset["title"].tolist().count("Same Title"), 2)
+
+    def test_build_reduced_dataset_extracts_directors_and_cast(self) -> None:
+        """Directors should split on commas and cast should include actresses."""
+        reducer = MovieDatasetReducer()
+        dataset = reducer.build_reduced_dataset(
+            titles=pd.DataFrame(
+                {
+                    "tconst": ["tt001"],
+                    "titleType": ["movie"],
+                    "primaryTitle": ["Movie A"],
+                    "genres": ["Action,Drama"],
+                }
+            ),
+            crew=pd.DataFrame(
+                {
+                    "tconst": ["tt001"],
+                    "directors": ["nm001,nm002,nm003,nm004"],
+                }
+            ),
+            ratings=pd.DataFrame(
+                {
+                    "tconst": ["tt001"],
+                    "averageRating": [8.0],
+                    "numVotes": [2000],
+                }
+            ),
+            names=pd.DataFrame(
+                {
+                    "nconst": [
+                        "nm001",
+                        "nm002",
+                        "nm003",
+                        "nm004",
+                        "nm101",
+                        "nm102",
+                        "nm103",
+                    ],
+                    "primaryName": [
+                        "Director One",
+                        "Director Two",
+                        "Director Three",
+                        "Director Four",
+                        "Actor One",
+                        "Actress One",
+                        "Writer One",
+                    ],
+                }
+            ),
+            principals=pd.DataFrame(
+                {
+                    "tconst": ["tt001", "tt001", "tt001"],
+                    "ordering": [2, 1, 3],
+                    "nconst": ["nm101", "nm102", "nm103"],
+                    "category": ["actor", "actress", "writer"],
+                }
+            ),
+            percentage=None,
+            min_votes=1000,
+        )
+        row = dataset.iloc[0]
+
+        self.assertEqual(row["director_ids"], ["nm001", "nm002", "nm003"])
+        self.assertEqual(
+            row["director_names"],
+            ["Director One", "Director Two", "Director Three"],
+        )
+        self.assertEqual(row["director"], "Director One")
+        self.assertEqual(row["actors"], ["Actress One", "Actor One"])
+        self.assertEqual(row["cast_ids"], ["nm102", "nm101"])
+        self.assertEqual(row["genres"], ["Action", "Drama"])
+        self.assertIsInstance(row["actors"], list)
+        self.assertIsInstance(row["genres"], list)
+
+    def test_build_reduced_dataset_uses_explicit_vote_threshold(self) -> None:
+        """The minimum-votes path should filter below-threshold movies."""
+        reducer = MovieDatasetReducer()
+        dataset = reducer.build_reduced_dataset(
+            titles=pd.DataFrame(
+                {
+                    "tconst": ["tt001", "tt002"],
+                    "titleType": ["movie", "movie"],
+                    "primaryTitle": ["Movie A", "Movie B"],
+                    "genres": ["Drama", "Drama"],
+                }
+            ),
+            crew=pd.DataFrame(
+                {
+                    "tconst": ["tt001", "tt002"],
+                    "directors": ["nm001", "nm002"],
+                }
+            ),
+            ratings=pd.DataFrame(
+                {
+                    "tconst": ["tt001", "tt002"],
+                    "averageRating": [7.0, 8.0],
+                    "numVotes": [999, 1000],
+                }
+            ),
+            names=pd.DataFrame(
+                {
+                    "nconst": ["nm001", "nm002"],
+                    "primaryName": ["Director One", "Director Two"],
+                }
+            ),
+            principals=pd.DataFrame(
+                {
+                    "tconst": ["tt001", "tt002"],
+                    "ordering": [1, 1],
+                    "nconst": ["nm001", "nm002"],
+                    "category": ["director", "director"],
+                }
+            ),
+            percentage=None,
+            min_votes=1000,
+        )
+
+        self.assertEqual(dataset["tconst"].tolist(), ["tt002"])
+
     def test_clean_data_and_create_soup(self) -> None:
         """Verify cleaning helpers and soup creation."""
         rec = MovieRecommender()

--- a/webapp/movies/test_movies.py
+++ b/webapp/movies/test_movies.py
@@ -70,7 +70,10 @@ class MovieUtilsTest(unittest.TestCase):
         )
 
         self.assertEqual(set(dataset["tconst"]), {"tt001", "tt002"})
-        self.assertEqual(dataset["title"].tolist().count("Same Title"), 2)
+        self.assertEqual(set(dataset["primary_title"]), {"Same Title"})
+        self.assertEqual(
+            set(dataset["title"]), {"Same Title (tt001)", "Same Title (tt002)"}
+        )
 
     def test_build_reduced_dataset_extracts_directors_and_cast(self) -> None:
         """Directors should split on commas and cast should include actresses."""
@@ -203,6 +206,33 @@ class MovieUtilsTest(unittest.TestCase):
         }
         soup = rec.create_soup(row)
         self.assertEqual(soup, "actorxactory directoradirectora actionthriller")
+
+    def test_load_dataset_disambiguates_duplicate_titles_with_tconst(self) -> None:
+        """Legacy tconst-bearing CSVs should not build ambiguous title indices."""
+        rec = MovieRecommender()
+        df = pd.DataFrame(
+            {
+                "tconst": ["tt001", "tt002", "tt003"],
+                "title": ["Same Title", "Same Title", "Other Title"],
+                "director": ["Director A", "Director B", "Director C"],
+                "genres": ["Action", "Comedy", "Drama"],
+                "score": [9.0, 8.0, 7.5],
+                "actors": ["Actor A", "Actor B", "Actor C"],
+            }
+        )
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False, mode="w+") as tmp:
+            df.to_csv(tmp.name, index=False)
+        try:
+            loaded = rec.load_dataset(Path(tmp.name))
+            result = rec.recommend("Same Title (tt001)", top_n=2).tolist()
+        finally:
+            os.unlink(tmp.name)
+
+        self.assertEqual(
+            loaded["title"].tolist(),
+            ["Same Title (tt001)", "Same Title (tt002)", "Other Title"],
+        )
+        self.assertEqual(result, ["Same Title (tt002)", "Other Title"])
 
     def test_load_and_recommend(self) -> None:
         """Loading a small dataset should enable recommendations."""


### PR DESCRIPTION
## Summary
- Preserve `tconst` through the reduced dataset and stop collapsing duplicate titles
- Split director IDs on commas, keep up to three director IDs/names, and retain the scalar `director` column for current consumers
- Include both `actor` and `actress` principals in cast extraction, preserving principal ordering up to five cast members
- Add explicit `--min-votes` CLI support with a 1,000-vote default
- Add typed list-valued reducer fields and best-effort Parquet output while preserving CSV output
- Add synthetic regression tests for duplicate titles, actress principals, multi-director splitting, typed list fields, and vote thresholding

Closes #24

## Verification
This branch is based on current `master`, where #22's `Makefile` is not merged yet, so I used the existing test command directly.

First, plain `python -m pytest -q` on the ambient shell failed because Django was not installed there:

```text
ModuleNotFoundError: No module named 'django'
```

Using the branch-local `.venv` created during implementation:

```bash
.venv/bin/python -m pytest -q
.........                                                                [100%]
9 passed in 2.58s
```

## Migration notes
- Current CSV-based app/CLI path is preserved.
- Parquet output is best-effort and skipped if pandas has no Parquet engine installed.
- The recommender still consumes the scalar `director` column; canonical list fields are now available for later migration work.
