### PR TITLE
Auto-merge Codex follow-up PRs into non-main branches

### DIFF
--- a/.github/workflows/codex-followup-automerge.yml
+++ b/.github/workflows/codex-followup-automerge.yml
@@ -1,0 +1,47 @@
+name: Auto-merge Codex follow-up PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    name: Enable auto-merge into non-main branches
+    if: >
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.base.ref != github.event.repository.default_branch &&
+      github.event.pull_request.base.ref != 'main' &&
+      github.event.pull_request.base.ref != 'master'
+    runs-on: ubuntu-latest
+    env:
+      # Set the CODEX_BOT_LOGIN repository variable if your Codex GitHub App
+      # uses a different bot login in pull_request.user.login.
+      CODEX_BOT_LOGIN: ${{ vars.CODEX_BOT_LOGIN || 'codex[bot]' }}
+      GH_TOKEN: ${{ github.token }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+    steps:
+      - name: Check PR author
+        id: author
+        run: |
+          if [ "$PR_AUTHOR" = "$CODEX_BOT_LOGIN" ]; then
+            echo "is_codex=true" >> "$GITHUB_OUTPUT"
+            echo "PR author matches configured Codex bot: $CODEX_BOT_LOGIN"
+          else
+            echo "is_codex=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping auto-merge for non-Codex PR author: $PR_AUTHOR"
+          fi
+
+      - name: Enable auto-merge
+        if: steps.author.outputs.is_codex == 'true'
+        run: |
+          gh pr merge "$PR_URL" --auto --squash --delete-branch --match-head-commit "$PR_HEAD_SHA"


### PR DESCRIPTION
### Motivation
- Enable automated merging of follow-up PRs created by the Codex bot into feature or other non-main branches to reduce manual merge steps and keep branches up to date.

### Description
- Add a new GitHub Actions workflow `codex-followup-automerge.yml` that triggers on `pull_request_target` events (`opened`, `reopened`, `synchronize`, `ready_for_review`).
- The job `enable-automerge` only runs for non-draft PRs whose base branch is not the repository default, `main`, or `master`, and it verifies the PR author matches `CODEX_BOT_LOGIN` (default `codex[bot]`).
- When the author matches, the workflow invokes the `gh` CLI to enable auto-merge with `--auto --squash --delete-branch --match-head-commit` for the PR head SHA.

### Testing
- No automated tests were executed as part of this change; the workflow file has been added to `.github/workflows` and will run on matching PR events in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25c260a6bc8332a03c376d8cd752e1)