### PR TITLE
Add canonical dataset artifact generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,18 @@ The older `venv/` directory name and the common `.venv/` directory are both igno
 Reduce IMDb data into a smaller CSV:
 
 ```bash
-python movies.py -p 0.90 -o movies_10
+make canonical-dataset IMDB_DATA_DIR=/path/to/imdb-tsvs
 ```
+
+The input directory must already contain `title.basics.tsv`, `title.crew.tsv`,
+`title.ratings.tsv`, `name.basics.tsv`, and `title.principals.tsv`; the project
+must not download real IMDb data automatically. By default the generated CSV is
+`movies_10.csv` in the repo root, matching the web app's default
+`RECOMMENDER_DATASET_PATH`. The reducer also tries to write `movies_10.parquet`
+as a typed artifact when optional pandas Parquet dependencies are installed. If
+Parquet support is missing, CSV generation still succeeds and typed output is
+logged as skipped. Use `python movies.py --input-dir /path/to/imdb-tsvs --output movies_10 --no-typed`
+to skip typed output explicitly.
 
 Run CLI recommendations:
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,12 @@ BASE_PYTHON ?= python
 VENV ?= .venv
 PYTHON ?= $(VENV)/bin/python
 UV_CACHE_DIR ?= .uv-cache
+IMDB_DATA_DIR ?= .
+DATASET_OUTPUT ?= movies_10
+DATASET_PERCENTAGE ?= 0.90
+DATASET_MIN_VOTES ?= 1000
 
-.PHONY: setup test run-web smoke clean
+.PHONY: setup test run-web smoke canonical-dataset clean
 
 setup:
 	@if [ ! -x "$(VENV)/bin/python" ]; then \
@@ -33,6 +37,9 @@ run-web:
 
 smoke:
 	$(PYTHON) webapp/manage.py check
+
+canonical-dataset:
+	$(PYTHON) movies.py --input-dir "$(IMDB_DATA_DIR)" --percentage "$(DATASET_PERCENTAGE)" --min-votes "$(DATASET_MIN_VOTES)" --output "$(DATASET_OUTPUT)"
 
 clean:
 	find . -type d \( -name __pycache__ -o -name .pytest_cache \) -prune -exec rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -39,6 +39,47 @@ Run the existing pytest suite from the repository root:
 make test
 ```
 
+## Canonical Dataset Artifact
+
+The app and CLI consume the reduced CSV artifact `movies_10.csv` in the project
+root by default. The reducer does not download IMDb data; place these IMDb TSV
+files in a local directory first:
+
+```text
+title.basics.tsv
+title.crew.tsv
+title.ratings.tsv
+name.basics.tsv
+title.principals.tsv
+```
+
+Generate the canonical reduced dataset from the repository root:
+
+```bash
+make canonical-dataset IMDB_DATA_DIR=/path/to/imdb-tsvs
+```
+
+This writes `movies_10.csv`, which is compatible with `recommender.py` and the
+Django app's default `RECOMMENDER_DATASET_PATH`. The CSV includes `tconst`,
+`primary_title`, director/cast IMDb ID lists, director/cast name lists, genres,
+score, and app-compatible title/director/actor columns. Duplicate primary titles
+are disambiguated with their `tconst`.
+
+The same command also attempts to write `movies_10.parquet` as a typed artifact.
+Parquet support is optional: if the installed pandas environment lacks a
+Parquet engine such as `pyarrow` or `fastparquet`, the reducer logs that typed
+output was skipped and still writes the CSV. To skip typed output explicitly:
+
+```bash
+python movies.py --input-dir /path/to/imdb-tsvs --output movies_10 --no-typed
+```
+
+You can override the artifact prefix and filter settings:
+
+```bash
+make canonical-dataset IMDB_DATA_DIR=/path/to/imdb-tsvs DATASET_OUTPUT=movies_10 DATASET_PERCENTAGE=0.90 DATASET_MIN_VOTES=1000
+```
+
 ### Future Work:
 - Make into a webapp using Django
 - Use database to provide backend data for webapp

--- a/movies.py
+++ b/movies.py
@@ -20,17 +20,33 @@ def main():
         "-o", "--output", default="movies_10", help="Output filename without extension"
     )
     parser.add_argument(
+        "--input-dir",
+        default=".",
+        help="Directory containing IMDb TSV files",
+    )
+    parser.add_argument(
         "--min-votes",
         type=int,
         default=1000,
         help="Minimum votes to keep; use 0 to rely only on --percentage",
+    )
+    parser.add_argument(
+        "--no-typed",
+        action="store_true",
+        help="Skip optional typed Parquet artifact generation",
     )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     reducer = MovieDatasetReducer()
-    reducer.reduce_dataset(args.percentage, args.output, min_votes=args.min_votes)
+    reducer.reduce_dataset(
+        args.percentage,
+        args.output,
+        min_votes=args.min_votes,
+        write_typed=not args.no_typed,
+        input_dir=args.input_dir,
+    )
 
 
 if __name__ == "__main__":

--- a/src/dataset_reducer.py
+++ b/src/dataset_reducer.py
@@ -42,7 +42,7 @@ class MovieDatasetReducer:
 
     @staticmethod
     def _read_tsv(
-        path: str,
+        path: str | Path,
         usecols: list[str],
         chunksize: int | None = 1000000,
     ) -> pd.DataFrame:
@@ -184,15 +184,16 @@ class MovieDatasetReducer:
 
     def _write_typed_output(
         self, metadata: pd.DataFrame, output_name: str | Path
-    ) -> None:
+    ) -> Path | None:
         """Write a typed artifact when pandas has Parquet engine support."""
         output_path = Path(f"{output_name}.parquet")
         try:
             metadata.to_parquet(output_path, index=False)
         except (ImportError, ValueError) as exc:
             logger.info("Skipped typed Parquet output: %s", exc)
-            return
+            return None
         logger.info("Saved typed dataset to %s", output_path)
+        return output_path
 
     def reduce_dataset(
         self,
@@ -200,6 +201,7 @@ class MovieDatasetReducer:
         output_name: str | Path,
         min_votes: int | None = DEFAULT_MIN_VOTES,
         write_typed: bool = True,
+        input_dir: str | Path = ".",
     ) -> pd.DataFrame:
         """Reduce the raw IMDb dump.
 
@@ -217,14 +219,19 @@ class MovieDatasetReducer:
         write_typed:
             Write a Parquet artifact next to the CSV when optional pandas
             dependencies support it.
+        input_dir:
+            Directory containing the required IMDb TSV input files.
         """
+        input_dir = Path(input_dir)
         logger.info("Getting movie dataset...")
         title = self._read_tsv(
-            "title.basics.tsv",
+            input_dir / "title.basics.tsv",
             ["tconst", "titleType", "primaryTitle", "genres"],
         )
-        director = self._read_tsv("title.crew.tsv", ["tconst", "directors"])
-        ratings = pd.read_csv("title.ratings.tsv", sep="\t", encoding="utf-8")
+        director = self._read_tsv(input_dir / "title.crew.tsv", ["tconst", "directors"])
+        ratings = pd.read_csv(
+            input_dir / "title.ratings.tsv", sep="\t", encoding="utf-8"
+        )
 
         logger.info(
             "Reducing data to %s%% of most popular movies with at least %s votes.",
@@ -233,11 +240,11 @@ class MovieDatasetReducer:
         )
 
         logger.info("Getting movie directors...")
-        names = self._read_tsv("name.basics.tsv", ["nconst", "primaryName"])
+        names = self._read_tsv(input_dir / "name.basics.tsv", ["nconst", "primaryName"])
 
         logger.info("Getting movie cast members...")
         cast = self._read_tsv(
-            "title.principals.tsv",
+            input_dir / "title.principals.tsv",
             ["tconst", "ordering", "nconst", "category"],
         )
 
@@ -252,7 +259,7 @@ class MovieDatasetReducer:
         )
 
         output_path = Path(f"{output_name}.csv")
-        metadata.to_csv(output_path)
+        metadata.to_csv(output_path, index=False)
         logger.info("Saved dataset to %s", output_path)
         if write_typed:
             self._write_typed_output(metadata, output_name)

--- a/webapp/movies/test_movies.py
+++ b/webapp/movies/test_movies.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import pandas as pd
 
@@ -191,6 +192,111 @@ class MovieUtilsTest(unittest.TestCase):
         )
 
         self.assertEqual(dataset["tconst"].tolist(), ["tt002"])
+
+    def test_reduce_dataset_writes_canonical_csv_artifact(self) -> None:
+        """The reducer command path should emit the canonical app-compatible CSV."""
+        reducer = MovieDatasetReducer()
+        expected_columns = [
+            "tconst",
+            "title",
+            "primary_title",
+            "director",
+            "director_ids",
+            "director_names",
+            "genres",
+            "score",
+            "cast_ids",
+            "actors",
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            input_dir = Path(tmp) / "imdb"
+            input_dir.mkdir()
+            pd.DataFrame(
+                {
+                    "tconst": ["tt001", "tt002"],
+                    "titleType": ["movie", "movie"],
+                    "primaryTitle": ["Same Title", "Same Title"],
+                    "genres": ["Drama", "Comedy"],
+                }
+            ).to_csv(input_dir / "title.basics.tsv", sep="\t", index=False)
+            pd.DataFrame(
+                {
+                    "tconst": ["tt001", "tt002"],
+                    "directors": ["nm001", "nm002"],
+                }
+            ).to_csv(input_dir / "title.crew.tsv", sep="\t", index=False)
+            pd.DataFrame(
+                {
+                    "tconst": ["tt001", "tt002"],
+                    "averageRating": [7.0, 8.0],
+                    "numVotes": [10, 20],
+                }
+            ).to_csv(input_dir / "title.ratings.tsv", sep="\t", index=False)
+            pd.DataFrame(
+                {
+                    "nconst": ["nm001", "nm002", "nm101", "nm102"],
+                    "primaryName": [
+                        "Director One",
+                        "Director Two",
+                        "Actor One",
+                        "Actor Two",
+                    ],
+                }
+            ).to_csv(input_dir / "name.basics.tsv", sep="\t", index=False)
+            pd.DataFrame(
+                {
+                    "tconst": ["tt001", "tt002"],
+                    "ordering": [1, 1],
+                    "nconst": ["nm101", "nm102"],
+                    "category": ["actor", "actor"],
+                }
+            ).to_csv(input_dir / "title.principals.tsv", sep="\t", index=False)
+
+            output_prefix = Path(tmp) / "movies_10"
+            dataset = reducer.reduce_dataset(
+                percentage=None,
+                output_name=output_prefix,
+                min_votes=0,
+                write_typed=False,
+                input_dir=input_dir,
+            )
+            csv_dataset = pd.read_csv(f"{output_prefix}.csv")
+            rec = MovieRecommender()
+            loaded = rec.load_dataset(f"{output_prefix}.csv")
+
+        self.assertEqual(dataset.columns.tolist(), expected_columns)
+        self.assertEqual(csv_dataset.columns.tolist(), expected_columns)
+        self.assertNotIn("Unnamed: 0", csv_dataset.columns)
+        self.assertEqual(set(csv_dataset["tconst"]), {"tt001", "tt002"})
+        self.assertEqual(set(csv_dataset["primary_title"]), {"Same Title"})
+        self.assertEqual(
+            set(csv_dataset["title"]), {"Same Title (tt001)", "Same Title (tt002)"}
+        )
+        self.assertIsInstance(dataset.loc[0, "director_ids"], list)
+        self.assertIsInstance(dataset.loc[0, "director_names"], list)
+        self.assertIsInstance(dataset.loc[0, "cast_ids"], list)
+        self.assertIsInstance(dataset.loc[0, "actors"], list)
+        self.assertIsInstance(dataset.loc[0, "genres"], list)
+        self.assertEqual(
+            set(loaded["title"]), {"Same Title (tt001)", "Same Title (tt002)"}
+        )
+
+    def test_typed_output_is_optional_when_parquet_engine_is_missing(self) -> None:
+        """Typed output should fall back clearly when optional support is absent."""
+        reducer = MovieDatasetReducer()
+        metadata = pd.DataFrame({"title": ["Movie A"]})
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_prefix = Path(tmp) / "movies_10"
+            with patch.object(
+                pd.DataFrame, "to_parquet", side_effect=ImportError("missing parquet")
+            ):
+                with self.assertLogs("src.dataset_reducer", level="INFO") as logs:
+                    typed_path = reducer._write_typed_output(metadata, output_prefix)
+
+        self.assertIsNone(typed_path)
+        self.assertIn("Skipped typed Parquet output: missing parquet", logs.output[0])
 
     def test_clean_data_and_create_soup(self) -> None:
         """Verify cleaning helpers and soup creation."""


### PR DESCRIPTION
## Summary
- Adds `make canonical-dataset` with configurable IMDb input directory, output prefix, percentage, and min-votes settings.
- Adds `movies.py --input-dir` and `--no-typed` flags.
- Writes app-compatible CSV output without a pandas index and optional Parquet typed artifact when supported.
- Adds tests for canonical output columns, `tconst`, list/canonical fields, duplicate-title recommender loading, and Parquet fallback.
- Documents dataset generation commands, required IMDb TSV inputs, output artifacts, and fallback behavior.

Closes #29

## Verification

```text
$ make test
.venv/bin/python -m pytest -q
.............                                                            [100%]
13 passed in 2.36s
```

```text
$ make smoke
.venv/bin/python webapp/manage.py check
System check identified no issues (0 silenced).
```

## Notes
- Real IMDb data is not downloaded automatically.
- Typed Parquet output is optional and logs a clear fallback when pandas lacks Parquet engine support.
- Checked tracked docs for local operator leakage (`/home/juno`, `codex-workspace`, `worktree`, `Juno`); none found.
