### PR TITLE
Add resource-safe IMDb data bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@ webapp/db.sqlite3
 
 # Build artifacts
 movies_*.csv
+movies_*.parquet
+data/
+imdb-data/
+*.tsv
+*.tsv.gz
 
 # Local-only agent notes, plans, and design docs
 .local-notes/

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,12 @@ VENV ?= .venv
 PYTHON ?= $(VENV)/bin/python
 UV_CACHE_DIR ?= .uv-cache
 IMDB_DATA_DIR ?= .
+IMDB_BOOTSTRAP_DIR ?= data/imdb
 DATASET_OUTPUT ?= movies_10
 DATASET_PERCENTAGE ?= 0.90
 DATASET_MIN_VOTES ?= 1000
 
-.PHONY: setup test run-web smoke canonical-dataset clean
+.PHONY: setup test run-web smoke imdb-bootstrap canonical-dataset clean
 
 setup:
 	@if [ ! -x "$(VENV)/bin/python" ]; then \
@@ -37,6 +38,9 @@ run-web:
 
 smoke:
 	$(PYTHON) webapp/manage.py check
+
+imdb-bootstrap:
+	$(PYTHON) imdb_bootstrap.py --output-dir "$(IMDB_BOOTSTRAP_DIR)" $(ARGS)
 
 canonical-dataset:
 	$(PYTHON) movies.py --input-dir "$(IMDB_DATA_DIR)" --percentage "$(DATASET_PERCENTAGE)" --min-votes "$(DATASET_MIN_VOTES)" --output "$(DATASET_OUTPUT)"

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ make test
 ## Canonical Dataset Artifact
 
 The app and CLI consume the reduced CSV artifact `movies_10.csv` in the project
-root by default. The reducer does not download IMDb data; place these IMDb TSV
-files in a local directory first:
+root by default. The reducer does not download IMDb data; bootstrap or place
+these IMDb TSV files in a local directory first:
 
 ```text
 title.basics.tsv
@@ -52,6 +52,64 @@ title.ratings.tsv
 name.basics.tsv
 title.principals.tsv
 ```
+
+## IMDb Source Data Bootstrap
+
+IMDb publishes the required source files at `https://datasets.imdbws.com/`.
+This project needs these compressed files:
+
+```text
+https://datasets.imdbws.com/title.basics.tsv.gz
+https://datasets.imdbws.com/title.crew.tsv.gz
+https://datasets.imdbws.com/title.ratings.tsv.gz
+https://datasets.imdbws.com/title.principals.tsv.gz
+https://datasets.imdbws.com/name.basics.tsv.gz
+```
+
+Use the bootstrap command to inspect or fetch the source files. It stores raw
+data under `data/imdb` by default, which is ignored by git.
+
+List required files and URLs without network access:
+
+```bash
+make imdb-bootstrap ARGS=--list
+```
+
+Preview the download plan without downloading anything:
+
+```bash
+make imdb-bootstrap ARGS=--dry-run
+```
+
+Create a tiny offline fixture set for development and tests:
+
+```bash
+make imdb-bootstrap ARGS="--sample --output-dir data/imdb-sample"
+make canonical-dataset IMDB_DATA_DIR=data/imdb-sample DATASET_OUTPUT=movies_sample DATASET_PERCENTAGE=0 DATASET_MIN_VOTES=0
+```
+
+Fetch the full compressed IMDb source files only when you are ready to perform
+the runtime operation with resource monitoring:
+
+```bash
+make imdb-bootstrap ARGS=--download
+```
+
+The bootstrap command streams compressed downloads to disk in 1 MiB chunks and
+fails closed if any compressed file exceeds the configured limit, which defaults
+to 2048 MiB per file. It does not decompress TSVs, load them into pandas, build
+recommendations, or generate reduced datasets. To change the cap:
+
+```bash
+make imdb-bootstrap ARGS="--download --max-file-size-mib 3072"
+```
+
+Plan for several GiB of compressed source data and tens of GiB if you later
+decompress the TSVs. Keep raw compressed files, decompressed TSVs, reduced CSVs,
+and Parquet artifacts out of git. On a shared 8 GB RAM VPS, do not run the
+current full-data recommendation path against raw IMDb files; the current
+recommender is an in-memory learning-era implementation and should only consume
+bounded reduced CSV artifacts.
 
 Generate the canonical reduced dataset from the repository root:
 

--- a/imdb_bootstrap.py
+++ b/imdb_bootstrap.py
@@ -1,0 +1,8 @@
+#! python
+"""Command line interface for safe IMDb source data bootstrap."""
+
+from src.imdb_bootstrap import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/imdb_bootstrap.py
+++ b/src/imdb_bootstrap.py
@@ -1,0 +1,288 @@
+"""Resource-safe bootstrap helpers for IMDb source datasets."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import shutil
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+
+IMDB_DATASET_BASE_URL = "https://datasets.imdbws.com"
+DEFAULT_OUTPUT_DIR = Path("data/imdb")
+DEFAULT_TIMEOUT_SECONDS = 60
+DEFAULT_CHUNK_SIZE_BYTES = 1024 * 1024
+DEFAULT_MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ImdbSourceFile:
+    """A required public IMDb source dataset file."""
+
+    filename: str
+
+    @property
+    def url(self) -> str:
+        return f"{IMDB_DATASET_BASE_URL}/{self.filename}"
+
+
+REQUIRED_SOURCE_FILES = [
+    ImdbSourceFile("title.basics.tsv.gz"),
+    ImdbSourceFile("title.crew.tsv.gz"),
+    ImdbSourceFile("title.ratings.tsv.gz"),
+    ImdbSourceFile("title.principals.tsv.gz"),
+    ImdbSourceFile("name.basics.tsv.gz"),
+]
+
+
+SAMPLE_TABLES = {
+    "title.basics.tsv": [
+        {
+            "tconst": "tt0000001",
+            "titleType": "movie",
+            "primaryTitle": "Sample Movie",
+            "genres": "Drama",
+        },
+        {
+            "tconst": "tt0000002",
+            "titleType": "movie",
+            "primaryTitle": "Sample Sequel",
+            "genres": "Comedy,Drama",
+        },
+        {
+            "tconst": "tt0000003",
+            "titleType": "short",
+            "primaryTitle": "Sample Short",
+            "genres": "Documentary",
+        },
+    ],
+    "title.crew.tsv": [
+        {"tconst": "tt0000001", "directors": "nm0000001"},
+        {"tconst": "tt0000002", "directors": "nm0000002"},
+        {"tconst": "tt0000003", "directors": "nm0000003"},
+    ],
+    "title.ratings.tsv": [
+        {"tconst": "tt0000001", "averageRating": "8.0", "numVotes": "1500"},
+        {"tconst": "tt0000002", "averageRating": "7.5", "numVotes": "1200"},
+        {"tconst": "tt0000003", "averageRating": "6.0", "numVotes": "10"},
+    ],
+    "title.principals.tsv": [
+        {
+            "tconst": "tt0000001",
+            "ordering": "1",
+            "nconst": "nm0000101",
+            "category": "actor",
+        },
+        {
+            "tconst": "tt0000001",
+            "ordering": "2",
+            "nconst": "nm0000102",
+            "category": "actress",
+        },
+        {
+            "tconst": "tt0000002",
+            "ordering": "1",
+            "nconst": "nm0000103",
+            "category": "actor",
+        },
+        {
+            "tconst": "tt0000003",
+            "ordering": "1",
+            "nconst": "nm0000104",
+            "category": "actor",
+        },
+    ],
+    "name.basics.tsv": [
+        {"nconst": "nm0000001", "primaryName": "Sample Director"},
+        {"nconst": "nm0000002", "primaryName": "Second Director"},
+        {"nconst": "nm0000101", "primaryName": "Sample Actor"},
+        {"nconst": "nm0000102", "primaryName": "Sample Actress"},
+        {"nconst": "nm0000103", "primaryName": "Sequel Actor"},
+        {"nconst": "nm0000003", "primaryName": "Short Director"},
+        {"nconst": "nm0000104", "primaryName": "Short Actor"},
+    ],
+}
+
+
+def _format_bytes(size: int) -> str:
+    value = float(size)
+    for unit in ["B", "KiB", "MiB", "GiB"]:
+        if value < 1024 or unit == "GiB":
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} GiB"
+
+
+def list_sources(output=sys.stdout) -> None:
+    """Print required IMDb source files and official public URLs."""
+    for source in REQUIRED_SOURCE_FILES:
+        print(f"{source.filename}\t{source.url}", file=output)
+
+
+def dry_run(output_dir: Path, output=sys.stdout) -> None:
+    """Print the download plan without opening network connections."""
+    print(f"Would store compressed IMDb source files in: {output_dir}", file=output)
+    for source in REQUIRED_SOURCE_FILES:
+        print(f"Would download {source.url} -> {output_dir / source.filename}", file=output)
+    print("No files downloaded; no TSVs decompressed or loaded into memory.", file=output)
+
+
+def download_sources(
+    output_dir: Path,
+    max_file_size_bytes: int = DEFAULT_MAX_FILE_SIZE_BYTES,
+    chunk_size_bytes: int = DEFAULT_CHUNK_SIZE_BYTES,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    output=sys.stdout,
+) -> list[Path]:
+    """Stream required compressed IMDb files into ``output_dir``."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    downloaded_paths = []
+    for source in REQUIRED_SOURCE_FILES:
+        destination = output_dir / source.filename
+        temp_path = None
+        if destination.exists():
+            print(f"Skipping existing file: {destination}", file=output)
+            downloaded_paths.append(destination)
+            continue
+
+        print(f"Downloading {source.url} -> {destination}", file=output)
+        try:
+            with urlopen(source.url, timeout=timeout_seconds) as response:
+                length_header = response.headers.get("Content-Length")
+                if length_header:
+                    content_length = int(length_header)
+                    if content_length > max_file_size_bytes:
+                        raise RuntimeError(
+                            f"{source.filename} is {_format_bytes(content_length)}, "
+                            f"above the configured limit of "
+                            f"{_format_bytes(max_file_size_bytes)}."
+                        )
+
+                with tempfile.NamedTemporaryFile(
+                    dir=output_dir, prefix=f".{source.filename}.", delete=False
+                ) as tmp:
+                    temp_path = Path(tmp.name)
+                    bytes_written = 0
+                    while True:
+                        chunk = response.read(chunk_size_bytes)
+                        if not chunk:
+                            break
+                        bytes_written += len(chunk)
+                        if bytes_written > max_file_size_bytes:
+                            raise RuntimeError(
+                                f"{source.filename} exceeded the configured limit of "
+                                f"{_format_bytes(max_file_size_bytes)}."
+                            )
+                        tmp.write(chunk)
+        except (HTTPError, URLError, TimeoutError) as exc:
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
+            raise RuntimeError(f"Failed to download {source.url}: {exc}") from exc
+        except Exception:
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
+            raise
+
+        shutil.move(str(temp_path), destination)
+        downloaded_paths.append(destination)
+        print(f"Saved {destination} ({_format_bytes(destination.stat().st_size)})", file=output)
+    return downloaded_paths
+
+
+def write_sample_fixture(
+    output_dir: Path,
+    rows_per_file: int = 5,
+    output=sys.stdout,
+) -> list[Path]:
+    """Write a tiny decompressed IMDb-compatible fixture set."""
+    if rows_per_file < 1:
+        raise ValueError("--sample-rows must be at least 1")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written_paths = []
+    for filename, rows in SAMPLE_TABLES.items():
+        path = output_dir / filename
+        selected_rows = rows[:rows_per_file]
+        with path.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(
+                handle, fieldnames=list(selected_rows[0]), delimiter="\t"
+            )
+            writer.writeheader()
+            writer.writerows(selected_rows)
+        written_paths.append(path)
+        print(f"Wrote sample fixture: {path}", file=output)
+    print("Sample fixture is intentionally tiny and offline-only.", file=output)
+    return written_paths
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Bootstrap required IMDb source data without loading it into memory."
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--list", action="store_true", help="List required files and URLs.")
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show the download plan without network access.",
+    )
+    mode.add_argument(
+        "--download",
+        action="store_true",
+        help="Stream compressed IMDb source files into the output directory.",
+    )
+    mode.add_argument(
+        "--sample",
+        action="store_true",
+        help="Write a tiny decompressed fixture set for local tests/development.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Destination directory. Default: {DEFAULT_OUTPUT_DIR}",
+    )
+    parser.add_argument(
+        "--max-file-size-mib",
+        type=int,
+        default=DEFAULT_MAX_FILE_SIZE_BYTES // (1024 * 1024),
+        help="Fail closed if any compressed download exceeds this size.",
+    )
+    parser.add_argument(
+        "--sample-rows",
+        type=int,
+        default=5,
+        help="Maximum rows to write per sample fixture file.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.list:
+        list_sources()
+        return 0
+    if args.dry_run:
+        dry_run(args.output_dir)
+        return 0
+    if args.sample:
+        write_sample_fixture(args.output_dir, rows_per_file=args.sample_rows)
+        return 0
+    if args.download:
+        max_file_size_bytes = args.max_file_size_mib * 1024 * 1024
+        download_sources(args.output_dir, max_file_size_bytes=max_file_size_bytes)
+        return 0
+
+    parser.error("select exactly one mode")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/webapp/movies/test_imdb_bootstrap.py
+++ b/webapp/movies/test_imdb_bootstrap.py
@@ -1,0 +1,73 @@
+"""Tests for the safe IMDb source bootstrap helpers."""
+
+from io import StringIO
+from pathlib import Path
+import tempfile
+import unittest
+
+import pandas as pd
+
+from src.dataset_reducer import MovieDatasetReducer
+from src.imdb_bootstrap import (
+    REQUIRED_SOURCE_FILES,
+    dry_run,
+    list_sources,
+    write_sample_fixture,
+)
+
+
+class ImdbBootstrapTest(unittest.TestCase):
+    """Bootstrap modes should stay offline and bounded unless explicitly downloading."""
+
+    def test_list_sources_prints_required_public_urls(self) -> None:
+        output = StringIO()
+
+        list_sources(output=output)
+
+        lines = output.getvalue().splitlines()
+        self.assertEqual(len(lines), 5)
+        for source, line in zip(REQUIRED_SOURCE_FILES, lines):
+            self.assertEqual(line, f"{source.filename}\t{source.url}")
+
+    def test_dry_run_does_not_create_output_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "imdb"
+            output = StringIO()
+
+            dry_run(output_dir, output=output)
+            output_dir_exists = output_dir.exists()
+
+        self.assertIn("No files downloaded", output.getvalue())
+        self.assertFalse(output_dir_exists)
+
+    def test_sample_fixture_is_small_and_reducer_compatible(self) -> None:
+        reducer = MovieDatasetReducer()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "sample"
+            paths = write_sample_fixture(output_dir, output=StringIO())
+            dataset = reducer.reduce_dataset(
+                percentage=None,
+                output_name=Path(tmp) / "movies_sample",
+                min_votes=0,
+                write_typed=False,
+                input_dir=output_dir,
+            )
+            max_rows = max(len(pd.read_csv(path, sep="\t")) for path in paths)
+
+        self.assertEqual(
+            {path.name for path in paths},
+            {
+                "title.basics.tsv",
+                "title.crew.tsv",
+                "title.ratings.tsv",
+                "title.principals.tsv",
+                "name.basics.tsv",
+            },
+        )
+        self.assertLessEqual(max_rows, 5)
+        self.assertEqual(dataset["tconst"].tolist(), ["tt0000001", "tt0000002"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a resource-safe IMDb bootstrap CLI (`imdb_bootstrap.py`) with `--list`, `--dry-run`, `--sample`, and explicit `--download` modes.
- Streams downloads in bounded chunks with per-file size caps and atomic temporary files.
- Adds `make imdb-bootstrap` and tests for source listing, dry-run behavior, sample fixture generation, and reducer compatibility with tiny fixture data.
- Expands `.gitignore` for local raw data directories, IMDb TSVs, compressed TSVs, and generated CSV/Parquet artifacts.
- Documents official IMDb source URLs, disk/RAM guidance, and the rule not to run full recommendations with the current in-memory path on the VPS.

Closes #32

## Verification

```text
$ make test
.venv/bin/python -m pytest -q
................                                                         [100%]
16 passed in 2.66s
```

```text
$ make smoke
.venv/bin/python webapp/manage.py check
System check identified no issues (0 silenced).
```

Offline bootstrap checks:

```text
$ make imdb-bootstrap ARGS=--list
title.basics.tsv.gz	https://datasets.imdbws.com/title.basics.tsv.gz
title.crew.tsv.gz	https://datasets.imdbws.com/title.crew.tsv.gz
title.ratings.tsv.gz	https://datasets.imdbws.com/title.ratings.tsv.gz
title.principals.tsv.gz	https://datasets.imdbws.com/title.principals.tsv.gz
name.basics.tsv.gz	https://datasets.imdbws.com/name.basics.tsv.gz
```

```text
$ make imdb-bootstrap ARGS=--dry-run
Would store compressed IMDb source files in: data/imdb
Would download https://datasets.imdbws.com/title.basics.tsv.gz -> data/imdb/title.basics.tsv.gz
Would download https://datasets.imdbws.com/title.crew.tsv.gz -> data/imdb/title.crew.tsv.gz
Would download https://datasets.imdbws.com/title.ratings.tsv.gz -> data/imdb/title.ratings.tsv.gz
Would download https://datasets.imdbws.com/title.principals.tsv.gz -> data/imdb/title.principals.tsv.gz
Would download https://datasets.imdbws.com/name.basics.tsv.gz -> data/imdb/name.basics.tsv.gz
No files downloaded; no TSVs decompressed or loaded into memory.
```

```text
$ make imdb-bootstrap ARGS="--sample --output-dir /tmp/movierec-sample-check"
Wrote sample fixture: /tmp/movierec-sample-check/title.basics.tsv
Wrote sample fixture: /tmp/movierec-sample-check/title.crew.tsv
Wrote sample fixture: /tmp/movierec-sample-check/title.ratings.tsv
Wrote sample fixture: /tmp/movierec-sample-check/title.principals.tsv
Wrote sample fixture: /tmp/movierec-sample-check/name.basics.tsv
Sample fixture is intentionally tiny and offline-only.
```

## Safety notes
- No real full IMDb download was performed.
- The PR adds tooling/docs/tests only; the real full download remains a supervised post-merge VPS runtime operation.
- Checked tracked docs for local operator workflow leakage (`/home/juno`, `codex-workspace`, `worktree`, `Juno`); none found.
