### PR TITLE
feat: add forced IMDb source refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,19 @@ recommendations, or generate reduced datasets. To change the cap:
 make imdb-bootstrap ARGS="--download --max-file-size-mib 3072"
 ```
 
+By default, existing compressed source files are skipped. Use `--force` only
+when you intentionally want to refresh local compressed sources that already
+exist:
+
+```bash
+make imdb-bootstrap ARGS="--download --force"
+```
+
+Forced refreshes still stream each compressed file to a temporary file in the
+output directory and atomically replace the existing file only after the
+download completes successfully. They still do not decompress TSVs or load full
+IMDb data into memory.
+
 Plan for several GiB of compressed source data and tens of GiB if you later
 decompress the TSVs. Keep raw compressed files, decompressed TSVs, reduced CSVs,
 SQLite stores, and Parquet artifacts out of git. On a shared 8 GB RAM VPS, do

--- a/src/imdb_bootstrap.py
+++ b/src/imdb_bootstrap.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import csv
-import shutil
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -137,6 +136,7 @@ def download_sources(
     max_file_size_bytes: int = DEFAULT_MAX_FILE_SIZE_BYTES,
     chunk_size_bytes: int = DEFAULT_CHUNK_SIZE_BYTES,
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    force: bool = False,
     output=sys.stdout,
 ) -> list[Path]:
     """Stream required compressed IMDb files into ``output_dir``."""
@@ -145,12 +145,13 @@ def download_sources(
     for source in REQUIRED_SOURCE_FILES:
         destination = output_dir / source.filename
         temp_path = None
-        if destination.exists():
+        if destination.exists() and not force:
             print(f"Skipping existing file: {destination}", file=output)
             downloaded_paths.append(destination)
             continue
 
-        print(f"Downloading {source.url} -> {destination}", file=output)
+        action = "Refreshing" if destination.exists() else "Downloading"
+        print(f"{action} {source.url} -> {destination}", file=output)
         try:
             with urlopen(source.url, timeout=timeout_seconds) as response:
                 length_header = response.headers.get("Content-Length")
@@ -188,7 +189,7 @@ def download_sources(
                 temp_path.unlink(missing_ok=True)
             raise
 
-        shutil.move(str(temp_path), destination)
+        temp_path.replace(destination)
         downloaded_paths.append(destination)
         print(f"Saved {destination} ({_format_bytes(destination.stat().st_size)})", file=output)
     return downloaded_paths
@@ -254,6 +255,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Fail closed if any compressed download exceeds this size.",
     )
     parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "With --download, redownload and atomically replace existing "
+            "compressed source files."
+        ),
+    )
+    parser.add_argument(
         "--sample-rows",
         type=int,
         default=5,
@@ -267,17 +276,27 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.list:
+        if args.force:
+            parser.error("--force can only be used with --download")
         list_sources()
         return 0
     if args.dry_run:
+        if args.force:
+            parser.error("--force can only be used with --download")
         dry_run(args.output_dir)
         return 0
     if args.sample:
+        if args.force:
+            parser.error("--force can only be used with --download")
         write_sample_fixture(args.output_dir, rows_per_file=args.sample_rows)
         return 0
     if args.download:
         max_file_size_bytes = args.max_file_size_mib * 1024 * 1024
-        download_sources(args.output_dir, max_file_size_bytes=max_file_size_bytes)
+        download_sources(
+            args.output_dir,
+            max_file_size_bytes=max_file_size_bytes,
+            force=args.force,
+        )
         return 0
 
     parser.error("select exactly one mode")

--- a/webapp/movies/test_imdb_bootstrap.py
+++ b/webapp/movies/test_imdb_bootstrap.py
@@ -4,16 +4,41 @@ from io import StringIO
 from pathlib import Path
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import pandas as pd
 
 from src.dataset_reducer import MovieDatasetReducer
 from src.imdb_bootstrap import (
     REQUIRED_SOURCE_FILES,
+    download_sources,
     dry_run,
     list_sources,
     write_sample_fixture,
 )
+
+
+class FakeDownloadResponse:
+    def __init__(self, chunks: list[bytes], fail_after_chunks: bool = False) -> None:
+        self.headers = {"Content-Length": str(sum(len(chunk) for chunk in chunks))}
+        self.chunks = chunks
+        self.fail_after_chunks = fail_after_chunks
+        self.index = 0
+
+    def __enter__(self) -> "FakeDownloadResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self, chunk_size: int) -> bytes:
+        if self.index < len(self.chunks):
+            chunk = self.chunks[self.index]
+            self.index += 1
+            return chunk
+        if self.fail_after_chunks:
+            raise RuntimeError("download failed")
+        return b""
 
 
 class ImdbBootstrapTest(unittest.TestCase):
@@ -39,6 +64,61 @@ class ImdbBootstrapTest(unittest.TestCase):
 
         self.assertIn("No files downloaded", output.getvalue())
         self.assertFalse(output_dir_exists)
+
+    def test_download_skips_existing_files_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "imdb"
+            output_dir.mkdir()
+            for source in REQUIRED_SOURCE_FILES:
+                (output_dir / source.filename).write_bytes(b"existing")
+
+            with patch("src.imdb_bootstrap.urlopen") as urlopen:
+                paths = download_sources(output_dir, output=StringIO())
+
+        urlopen.assert_not_called()
+        self.assertEqual(len(paths), len(REQUIRED_SOURCE_FILES))
+
+    def test_download_force_replaces_existing_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "imdb"
+            output_dir.mkdir()
+            for source in REQUIRED_SOURCE_FILES:
+                (output_dir / source.filename).write_bytes(b"existing")
+            output = StringIO()
+
+            with patch(
+                "src.imdb_bootstrap.urlopen",
+                side_effect=lambda *args, **kwargs: FakeDownloadResponse([b"replacement"]),
+            ) as urlopen:
+                paths = download_sources(output_dir, force=True, output=output)
+
+            contents = [(output_dir / source.filename).read_bytes() for source in REQUIRED_SOURCE_FILES]
+
+        self.assertEqual(urlopen.call_count, len(REQUIRED_SOURCE_FILES))
+        self.assertEqual(contents, [b"replacement"] * len(REQUIRED_SOURCE_FILES))
+        self.assertEqual(len(paths), len(REQUIRED_SOURCE_FILES))
+        self.assertIn("Refreshing", output.getvalue())
+
+    def test_download_force_failure_preserves_existing_file_and_removes_temp_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "imdb"
+            output_dir.mkdir()
+            first_source = REQUIRED_SOURCE_FILES[0]
+            for source in REQUIRED_SOURCE_FILES:
+                (output_dir / source.filename).write_bytes(b"existing")
+
+            with patch(
+                "src.imdb_bootstrap.urlopen",
+                return_value=FakeDownloadResponse([b"partial"], fail_after_chunks=True),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "download failed"):
+                    download_sources(output_dir, force=True, output=StringIO())
+
+            preserved_content = (output_dir / first_source.filename).read_bytes()
+            temp_files = [path for path in output_dir.iterdir() if path.name.startswith(".")]
+
+        self.assertEqual(preserved_content, b"existing")
+        self.assertEqual(temp_files, [])
 
     def test_sample_fixture_is_small_and_reducer_compatible(self) -> None:
         reducer = MovieDatasetReducer()


### PR DESCRIPTION
## Summary
- Add `--force` for IMDb source downloads so existing compressed files can be intentionally refreshed.
- Preserve default skip behavior for existing files when `--force` is not set.
- Replace refreshed files only after a complete temp-file download succeeds, preserving existing files and cleaning temp files on failure.
- Document forced refresh behavior in the README.

Closes #38

## Verification
```text
.venv/bin/python -m pytest -q webapp/movies/test_imdb_bootstrap.py
......                                                                   [100%]
6 passed in 0.75s
```

```text
make test
.venv/bin/python -m pytest -q
..................................                                       [100%]
34 passed in 3.92s
```

```text
make smoke
.venv/bin/python webapp/manage.py check
System check identified no issues (0 silenced).
```

```text
make imdb-bootstrap ARGS=--dry-run
.venv/bin/python imdb_bootstrap.py --output-dir "data/imdb" --dry-run
Would store compressed IMDb source files in: data/imdb
Would download https://datasets.imdbws.com/title.basics.tsv.gz -> data/imdb/title.basics.tsv.gz
Would download https://datasets.imdbws.com/title.crew.tsv.gz -> data/imdb/title.crew.tsv.gz
Would download https://datasets.imdbws.com/title.ratings.tsv.gz -> data/imdb/title.ratings.tsv.gz
Would download https://datasets.imdbws.com/title.principals.tsv.gz -> data/imdb/title.principals.tsv.gz
Would download https://datasets.imdbws.com/name.basics.tsv.gz -> data/imdb/name.basics.tsv.gz
No files downloaded; no TSVs decompressed or loaded into memory.
```

## Known blockers
None.
