### PR TITLE
issue #39: add recommendation evaluation harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DATASET_OUTPUT ?= movies_10
 DATASET_PERCENTAGE ?= 0.90
 DATASET_MIN_VOTES ?= 1000
 
-.PHONY: setup test run-web smoke imdb-bootstrap canonical-dataset clean
+.PHONY: setup test run-web smoke imdb-bootstrap canonical-dataset evaluate-recommendations clean
 
 setup:
 	@if [ ! -x "$(VENV)/bin/python" ]; then \
@@ -44,6 +44,9 @@ imdb-bootstrap:
 
 canonical-dataset:
 	$(PYTHON) movies.py --input-dir "$(IMDB_DATA_DIR)" --percentage "$(DATASET_PERCENTAGE)" --min-votes "$(DATASET_MIN_VOTES)" --output "$(DATASET_OUTPUT)"
+
+evaluate-recommendations:
+	$(PYTHON) evaluate_recommendations.py $(ARGS)
 
 clean:
 	find . -type d \( -name __pycache__ -o -name .pytest_cache \) -prune -exec rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -217,6 +217,36 @@ This command uses the bounded SQLite preview store by default. It does not load
 the full reduced CSV into pandas and does not build an all-pairs similarity
 matrix.
 
+## Recommendation Quality Evaluation
+
+The repo includes a tiny offline evaluation harness for the current bounded
+SQLite recommendation path. It uses:
+
+- `fixtures/recommendation_eval_movies.csv` as a small tracked movie dataset,
+- `fixtures/recommendation_eval_cases.json` as curated seed cases with
+  expected-good titles, expected-bad titles, and failure-mode notes,
+- a temporary SQLite store by default, so no generated database is written into
+  the worktree.
+
+Run it from the repository root:
+
+```bash
+make evaluate-recommendations
+```
+
+Or pass CLI options directly:
+
+```bash
+python evaluate_recommendations.py --top-n 3 --candidate-limit 250
+```
+
+The report is intentionally human-readable. `Expected-good hits` counts seed
+titles that appeared in the top-N results. `Expected-bad misses` counts titles
+that stayed out of the top-N results. `Expected errors` covers known failure
+modes, such as a missing query title. The command exits with status 0 only when
+all seed cases pass, which makes it usable in local checks or CI without adding
+a full benchmark framework.
+
 ### Future Work:
 - Make into a webapp using Django
 - Use database to provide backend data for webapp

--- a/evaluate_recommendations.py
+++ b/evaluate_recommendations.py
@@ -1,0 +1,65 @@
+#! python
+"""Command line entrypoint for recommendation quality evaluation."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.recommendation_evaluation import (
+    DEFAULT_EVALUATION_CASES,
+    DEFAULT_EVALUATION_DATASET,
+    evaluate_recommendations,
+    write_report,
+)
+from src.sqlite_recommender import SQLiteMovieRecommender
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate the bounded SQLite recommender against seed cases."
+    )
+    parser.add_argument(
+        "--dataset",
+        type=Path,
+        default=DEFAULT_EVALUATION_DATASET,
+        help=f"Evaluation CSV fixture. Default: {DEFAULT_EVALUATION_DATASET}",
+    )
+    parser.add_argument(
+        "--cases",
+        type=Path,
+        default=DEFAULT_EVALUATION_CASES,
+        help=f"Evaluation seed JSON. Default: {DEFAULT_EVALUATION_CASES}",
+    )
+    parser.add_argument(
+        "--store",
+        type=Path,
+        help="Optional SQLite store path. Defaults to a temporary file.",
+    )
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        help="Override top_n for every seed case.",
+    )
+    parser.add_argument(
+        "--candidate-limit",
+        type=int,
+        default=SQLiteMovieRecommender.DEFAULT_CANDIDATE_LIMIT,
+        help="Maximum shared-term candidates to rank before score fallback.",
+    )
+    args = parser.parse_args()
+
+    report = evaluate_recommendations(
+        dataset_path=args.dataset,
+        cases_path=args.cases,
+        store_path=args.store,
+        top_n=args.top_n,
+        candidate_limit=args.candidate_limit,
+    )
+    write_report(report, sys.stdout)
+    return 0 if report.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fixtures/recommendation_eval_cases.json
+++ b/fixtures/recommendation_eval_cases.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "scorer": "sqlite-bounded-term-overlap",
+  "description": "Tiny offline seeds for the bounded SQLite recommender path.",
+  "cases": [
+    {
+      "id": "crime-shared-terms",
+      "query": "Neon Heist",
+      "top_n": 3,
+      "expected_good": ["Midnight Crew", "Crime Alley"],
+      "expected_bad": ["Romantic Kitchen"],
+      "failure_mode": "Action/crime seeds should prefer shared cast or genre over unrelated high-level fallback titles.",
+      "notes": "Midnight Crew shares action, crime, and Mara Vale; Crime Alley shares crime."
+    },
+    {
+      "id": "scifi-adventure-cluster",
+      "query": "Space Garden",
+      "top_n": 3,
+      "expected_good": ["Galaxy Chase", "Deep Space Laughs"],
+      "expected_bad": ["Romantic Kitchen"],
+      "failure_mode": "Sci-fi/adventure recommendations should not be displaced by unrelated comedy/romance titles.",
+      "notes": "Galaxy Chase shares sci-fi, adventure, and Noah Reed; Deep Space Laughs shares sci-fi."
+    },
+    {
+      "id": "missing-title",
+      "query": "Not In Fixture",
+      "top_n": 3,
+      "expected_good": [],
+      "expected_bad": [],
+      "expected_error": "This movie is not in the dataset.",
+      "failure_mode": "Unknown titles should be reported as expected failures instead of crashing the harness.",
+      "notes": "Keeps the report honest about lookup failures."
+    }
+  ]
+}

--- a/fixtures/recommendation_eval_movies.csv
+++ b/fixtures/recommendation_eval_movies.csv
@@ -1,0 +1,9 @@
+tconst,title,primary_title,director,genres,score,actors
+tt001,Neon Heist,Neon Heist,Ava Lin,"['Action', 'Crime']",8.7,"['Mara Vale', 'Jon Pike']"
+tt002,Midnight Crew,Midnight Crew,Ben Ortiz,"['Action', 'Crime']",8.2,"['Mara Vale', 'Luis Chen']"
+tt003,Silent Orchard,Silent Orchard,Cora Shah,"['Drama']",9.0,"['Iris Moon']"
+tt004,Space Garden,Space Garden,Dina Park,"['Sci-Fi', 'Adventure']",8.5,"['Noah Reed']"
+tt005,Galaxy Chase,Galaxy Chase,Eli Stone,"['Sci-Fi', 'Adventure']",8.3,"['Noah Reed', 'Uma Fox']"
+tt006,Romantic Kitchen,Romantic Kitchen,Faye Moore,"['Romance', 'Comedy']",7.9,"['Lena Hart']"
+tt007,Deep Space Laughs,Deep Space Laughs,Gabe Yu,"['Comedy', 'Sci-Fi']",7.2,"['Omar Bell']"
+tt008,Crime Alley,Crime Alley,Hana West,"['Crime', 'Thriller']",7.5,"['Luis Chen']"

--- a/src/recommendation_evaluation.py
+++ b/src/recommendation_evaluation.py
@@ -1,0 +1,259 @@
+"""Small recommendation quality evaluator for the SQLite preview path."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TextIO
+
+from src.sqlite_recommender import SQLiteMovieRecommender
+
+
+DEFAULT_EVALUATION_DATASET = Path("fixtures/recommendation_eval_movies.csv")
+DEFAULT_EVALUATION_CASES = Path("fixtures/recommendation_eval_cases.json")
+
+
+@dataclass(frozen=True)
+class EvaluationCase:
+    """One seed query and its expected recommendation behavior."""
+
+    case_id: str
+    query: str
+    top_n: int
+    expected_good: tuple[str, ...]
+    expected_bad: tuple[str, ...]
+    expected_error: str | None = None
+    failure_mode: str = ""
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    """Evaluation outcome for one seed case."""
+
+    case: EvaluationCase
+    recommendations: tuple[str, ...]
+    error: str | None
+    missing_good: tuple[str, ...]
+    present_bad: tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        if self.case.expected_error:
+            return (
+                self.error is not None
+                and self.case.expected_error in self.error
+                and not self.recommendations
+            )
+        return self.error is None and not self.missing_good and not self.present_bad
+
+
+@dataclass(frozen=True)
+class EvaluationReport:
+    """Aggregate recommendation evaluation results."""
+
+    dataset_path: Path
+    cases_path: Path
+    scorer: str
+    results: tuple[CaseResult, ...]
+
+    @property
+    def passed(self) -> bool:
+        return all(result.passed for result in self.results)
+
+    @property
+    def expected_good_hits(self) -> int:
+        return sum(
+            len(result.case.expected_good) - len(result.missing_good)
+            for result in self.results
+        )
+
+    @property
+    def expected_good_total(self) -> int:
+        return sum(len(result.case.expected_good) for result in self.results)
+
+    @property
+    def expected_bad_absent(self) -> int:
+        return sum(
+            len(result.case.expected_bad) - len(result.present_bad)
+            for result in self.results
+        )
+
+    @property
+    def expected_bad_total(self) -> int:
+        return sum(len(result.case.expected_bad) for result in self.results)
+
+    @property
+    def expected_error_hits(self) -> int:
+        return sum(
+            1
+            for result in self.results
+            if result.case.expected_error
+            and result.error
+            and result.case.expected_error in result.error
+        )
+
+    @property
+    def expected_error_total(self) -> int:
+        return sum(1 for result in self.results if result.case.expected_error)
+
+
+def load_evaluation_cases(cases_path: str | Path) -> tuple[str, tuple[EvaluationCase, ...]]:
+    """Load seed cases from the tracked JSON fixture."""
+    path = Path(cases_path)
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    cases = []
+    for raw_case in payload["cases"]:
+        cases.append(
+            EvaluationCase(
+                case_id=raw_case["id"],
+                query=raw_case["query"],
+                top_n=int(raw_case.get("top_n", 10)),
+                expected_good=tuple(raw_case.get("expected_good", [])),
+                expected_bad=tuple(raw_case.get("expected_bad", [])),
+                expected_error=raw_case.get("expected_error"),
+                failure_mode=raw_case.get("failure_mode", ""),
+                notes=raw_case.get("notes", ""),
+            )
+        )
+    return payload.get("scorer", "sqlite-bounded-term-overlap"), tuple(cases)
+
+
+def evaluate_recommendations(
+    dataset_path: str | Path = DEFAULT_EVALUATION_DATASET,
+    cases_path: str | Path = DEFAULT_EVALUATION_CASES,
+    store_path: str | Path | None = None,
+    top_n: int | None = None,
+    candidate_limit: int = SQLiteMovieRecommender.DEFAULT_CANDIDATE_LIMIT,
+) -> EvaluationReport:
+    """Run seed cases against the current bounded SQLite recommender."""
+    dataset = Path(dataset_path)
+    cases_file = Path(cases_path)
+    scorer, cases = load_evaluation_cases(cases_file)
+
+    if store_path is None:
+        with tempfile.TemporaryDirectory() as tmp:
+            return _evaluate_with_store(
+                dataset,
+                cases_file,
+                Path(tmp) / "recommendation_eval.sqlite",
+                cases,
+                scorer,
+                top_n,
+                candidate_limit,
+            )
+
+    return _evaluate_with_store(
+        dataset,
+        cases_file,
+        Path(store_path),
+        cases,
+        scorer,
+        top_n,
+        candidate_limit,
+    )
+
+
+def _evaluate_with_store(
+    dataset_path: Path,
+    cases_path: Path,
+    store_path: Path,
+    cases: tuple[EvaluationCase, ...],
+    scorer: str,
+    top_n: int | None,
+    candidate_limit: int,
+) -> EvaluationReport:
+    recommender = SQLiteMovieRecommender.from_csv(
+        dataset_path,
+        store_path,
+        candidate_limit=candidate_limit,
+    )
+    results = []
+    for case in cases:
+        effective_top_n = case.top_n if top_n is None else top_n
+        effective_case = EvaluationCase(
+            case_id=case.case_id,
+            query=case.query,
+            top_n=effective_top_n,
+            expected_good=case.expected_good,
+            expected_bad=case.expected_bad,
+            expected_error=case.expected_error,
+            failure_mode=case.failure_mode,
+            notes=case.notes,
+        )
+        results.append(_evaluate_case(recommender, effective_case))
+    return EvaluationReport(dataset_path, cases_path, scorer, tuple(results))
+
+
+def _evaluate_case(
+    recommender: SQLiteMovieRecommender,
+    case: EvaluationCase,
+) -> CaseResult:
+    recommendations: tuple[str, ...] = ()
+    error = None
+    try:
+        recommendations = tuple(recommender.recommend(case.query, top_n=case.top_n))
+    except ValueError as exc:
+        error = str(exc)
+
+    missing_good = tuple(
+        title for title in case.expected_good if title not in recommendations
+    )
+    present_bad = tuple(title for title in case.expected_bad if title in recommendations)
+    return CaseResult(case, recommendations, error, missing_good, present_bad)
+
+
+def write_report(report: EvaluationReport, output: TextIO) -> None:
+    """Write a human-readable report for local comparison and CI logs."""
+    passed = sum(1 for result in report.results if result.passed)
+    total = len(report.results)
+    print("Recommendation Quality Evaluation", file=output)
+    print(f"Scorer: {report.scorer}", file=output)
+    print(f"Dataset: {report.dataset_path}", file=output)
+    print(f"Seeds: {report.cases_path}", file=output)
+    print(f"Cases: {passed}/{total} passed", file=output)
+    print(
+        "Expected-good hits: "
+        f"{report.expected_good_hits}/{report.expected_good_total}",
+        file=output,
+    )
+    print(
+        "Expected-bad misses: "
+        f"{report.expected_bad_absent}/{report.expected_bad_total}",
+        file=output,
+    )
+    print(
+        "Expected errors: "
+        f"{report.expected_error_hits}/{report.expected_error_total}",
+        file=output,
+    )
+    print("", file=output)
+
+    for result in report.results:
+        status = "PASS" if result.passed else "FAIL"
+        print(f"[{status}] {result.case.case_id}: {result.case.query}", file=output)
+        if result.error is not None:
+            print(f"  error: {result.error}", file=output)
+        else:
+            joined = ", ".join(result.recommendations) or "(none)"
+            print(f"  top {result.case.top_n}: {joined}", file=output)
+        _write_expectations(result, output)
+        if result.case.failure_mode:
+            print(f"  failure mode: {result.case.failure_mode}", file=output)
+        if result.case.notes:
+            print(f"  notes: {result.case.notes}", file=output)
+
+
+def _write_expectations(result: CaseResult, output: TextIO) -> None:
+    if result.case.expected_good:
+        missing = ", ".join(result.missing_good) or "(none)"
+        print(f"  missing expected good: {missing}", file=output)
+    if result.case.expected_bad:
+        present = ", ".join(result.present_bad) or "(none)"
+        print(f"  present expected bad: {present}", file=output)
+    if result.case.expected_error:
+        print(f"  expected error: {result.case.expected_error}", file=output)

--- a/webapp/movies/test_recommendation_evaluation.py
+++ b/webapp/movies/test_recommendation_evaluation.py
@@ -1,0 +1,85 @@
+"""Tests for the recommendation quality evaluation harness."""
+
+from io import StringIO
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from src.recommendation_evaluation import (
+    DEFAULT_EVALUATION_CASES,
+    DEFAULT_EVALUATION_DATASET,
+    evaluate_recommendations,
+    write_report,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class RecommendationEvaluationTest(unittest.TestCase):
+    """The harness should report repeatable seed-case outcomes."""
+
+    def test_default_seed_report_passes(self) -> None:
+        output = StringIO()
+
+        report = evaluate_recommendations()
+        write_report(report, output)
+
+        self.assertTrue(report.passed)
+        self.assertEqual(report.expected_good_hits, 4)
+        self.assertEqual(report.expected_bad_absent, 2)
+        self.assertIn("Cases: 3/3 passed", output.getvalue())
+        self.assertIn("[PASS] crime-shared-terms: Neon Heist", output.getvalue())
+        self.assertIn("Expected errors: 1/1", output.getvalue())
+
+    def test_report_flags_expected_bad_recommendation(self) -> None:
+        failing_cases = {
+            "schema_version": 1,
+            "scorer": "sqlite-bounded-term-overlap",
+            "cases": [
+                {
+                    "id": "bad-title-present",
+                    "query": "Neon Heist",
+                    "top_n": 3,
+                    "expected_good": ["Midnight Crew"],
+                    "expected_bad": ["Midnight Crew"],
+                    "failure_mode": "Expected-bad titles should fail when present.",
+                    "notes": "Intentional failing seed for report coverage.",
+                }
+            ],
+        }
+        output = StringIO()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cases_path = Path(tmp) / "cases.json"
+            cases_path.write_text(json.dumps(failing_cases), encoding="utf-8")
+            report = evaluate_recommendations(
+                dataset_path=DEFAULT_EVALUATION_DATASET,
+                cases_path=cases_path,
+            )
+            write_report(report, output)
+
+        self.assertFalse(report.passed)
+        self.assertIn("Cases: 0/1 passed", output.getvalue())
+        self.assertIn("[FAIL] bad-title-present: Neon Heist", output.getvalue())
+        self.assertIn("present expected bad: Midnight Crew", output.getvalue())
+
+    def test_cli_report_command_exits_successfully_for_default_seeds(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "evaluate_recommendations.py"],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Recommendation Quality Evaluation", result.stdout)
+        self.assertIn(str(DEFAULT_EVALUATION_CASES), result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a tiny offline recommendation evaluation harness for the bounded SQLite recommender path.
- Adds tracked seed cases and fixture movies covering expected-good, expected-bad, and expected-error behavior.
- Documents `make evaluate-recommendations` and wires the Makefile target.

## Verification
```text
$ make test && make smoke && make evaluate-recommendations
.venv/bin/python -m pytest -q
.....................................                                    [100%]
37 passed in 4.35s
.venv/bin/python webapp/manage.py check
System check identified no issues (0 silenced).
.venv/bin/python evaluate_recommendations.py 
Recommendation Quality Evaluation
Scorer: sqlite-bounded-term-overlap
Dataset: fixtures/recommendation_eval_movies.csv
Seeds: fixtures/recommendation_eval_cases.json
Cases: 3/3 passed
Expected-good hits: 4/4
Expected-bad misses: 2/2
Expected errors: 1/1
```

Closes #39
