### PR TITLE
issue #30: private preview path for current web app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ IMDB_BOOTSTRAP_DIR ?= data/imdb
 DATASET_OUTPUT ?= movies_10
 DATASET_PERCENTAGE ?= 0.90
 DATASET_MIN_VOTES ?= 1000
+WEB_BIND ?= 127.0.0.1:8000
 
 .PHONY: setup test run-web smoke imdb-bootstrap canonical-dataset clean
 
@@ -34,7 +35,7 @@ test:
 	$(PYTHON) -m pytest -q
 
 run-web:
-	$(PYTHON) webapp/manage.py runserver
+	$(PYTHON) webapp/manage.py runserver $(WEB_BIND)
 
 smoke:
 	$(PYTHON) webapp/manage.py check

--- a/README.md
+++ b/README.md
@@ -252,6 +252,9 @@ For a quick Django configuration check, run:
 make smoke
 ```
 
+For a private VPS preview using an SSH tunnel or trusted private network, see
+[`docs/private-vps-preview.md`](docs/private-vps-preview.md).
+
 ## Implementation reports
 
 When reporting completed implementation work, include the changed files, exact

--- a/docs/private-vps-preview.md
+++ b/docs/private-vps-preview.md
@@ -1,0 +1,124 @@
+# Private VPS Preview
+
+This is an operator runbook for a private, manually visitable preview of the
+current Django app. It uses the bounded SQLite recommendation path already in
+the repo and intentionally avoids public DNS, TLS, production deployment, and
+new serving architecture.
+
+## Build Preview Artifacts
+
+Use existing reduced artifacts when they are already available:
+
+```bash
+python recommender.py movies_10.csv "Inception" \
+  --store movies_10.sqlite \
+  --candidate-limit 500
+```
+
+If real IMDb TSVs or reduced artifacts are unavailable, build the tiny offline
+fixture instead. These generated files are under ignored paths and must not be
+committed:
+
+```bash
+make setup
+mkdir -p data/preview
+make imdb-bootstrap ARGS="--sample --output-dir data/imdb-sample"
+make canonical-dataset \
+  IMDB_DATA_DIR=data/imdb-sample \
+  DATASET_OUTPUT=data/preview/movies_preview \
+  DATASET_PERCENTAGE=0 \
+  DATASET_MIN_VOTES=0
+python recommender.py data/preview/movies_preview.csv "Sample Movie" \
+  --store data/preview/movies_preview.sqlite \
+  --candidate-limit 250
+```
+
+## Start The Private Preview
+
+SSH tunnel mode keeps Django bound to loopback on the VPS:
+
+```bash
+RECOMMENDER_DATASET_PATH=data/preview/movies_preview.csv \
+RECOMMENDER_STORE_PATH=data/preview/movies_preview.sqlite \
+RECOMMENDER_CANDIDATE_LIMIT=250 \
+make run-web WEB_BIND=127.0.0.1:8000
+```
+
+From your workstation, open a tunnel to the VPS:
+
+```bash
+ssh -N -L 8000:127.0.0.1:8000 <vps-ssh-host>
+```
+
+Then visit `http://127.0.0.1:8000/` locally.
+
+Trusted private-network mode is also acceptable when the VPS firewall and
+network already restrict access. Bind to the private interface and set the
+expected hostnames or private IPs:
+
+```bash
+DJANGO_ALLOWED_HOSTS=127.0.0.1,localhost,<private-host-or-ip> \
+RECOMMENDER_DATASET_PATH=data/preview/movies_preview.csv \
+RECOMMENDER_STORE_PATH=data/preview/movies_preview.sqlite \
+RECOMMENDER_CANDIDATE_LIMIT=250 \
+make run-web WEB_BIND=0.0.0.0:8000
+```
+
+Visit `http://<private-host-or-ip>:8000/` from the trusted network only.
+
+## Smoke Checks
+
+Run the Django checks before starting the preview:
+
+```bash
+make smoke
+```
+
+After the server starts, verify the page is reachable:
+
+```bash
+curl -fsS http://127.0.0.1:8000/ >/tmp/movierec-preview-home.html
+```
+
+Use the browser for recommendation requests so Django's CSRF form flow is
+exercised normally.
+
+The development server can warn about unapplied Django admin/auth/session
+migrations in a fresh checkout. The search preview path does not use those
+tables. To silence the warning for a longer manual session, run:
+
+```bash
+.venv/bin/python webapp/manage.py migrate
+```
+
+## Shutdown
+
+Stop the Django server with `Ctrl-C`. Stop the SSH tunnel with `Ctrl-C` in the
+tunnel terminal. Generated preview artifacts can be removed when no longer
+needed:
+
+```bash
+rm -rf data/preview data/imdb-sample
+```
+
+## Manual E2E Checklist
+
+Record these observations in the issue or PR report after running the preview:
+
+| Check | Action | Expected or observed result |
+| --- | --- | --- |
+| Homepage loads | Visit `http://127.0.0.1:8000/` through the tunnel, or the private-network URL. | Search form renders with HTTP 200. |
+| Known-title recommendation | Search `Sample Movie` when using the fixture, or a known title from the real artifact. | Fixture returns `Sample Sequel`; real artifact returns recommendations from the SQLite store. |
+| Missing-title error | Search a title that is not in the artifact. | Page stays usable and shows `This movie is not in the dataset.` |
+| Duplicate-title behavior | If the artifact contains duplicate primary titles, search the disambiguated `Title (tconst)` value. | The app accepts the disambiguated title; sample fixture has no duplicate-title case. |
+| Artifact path | Confirm `RECOMMENDER_STORE_PATH` points at the intended ignored SQLite artifact. | App starts without reading raw IMDb TSV files at request time. |
+| Shutdown | Stop `runserver` and any tunnel process. | Preview is no longer reachable. |
+
+Observed local fixture smoke for this change:
+
+| Check | Result |
+| --- | --- |
+| Fixture artifact build | `make imdb-bootstrap ARGS="--sample --output-dir data/imdb-sample"`, `make canonical-dataset ...`, and `python recommender.py ... "Sample Movie"` completed; recommender returned `['Sample Sequel']`. |
+| `make smoke` | Passed with `System check identified no issues (0 silenced).` |
+| HTTP preview smoke | `runserver` on `127.0.0.1:8765` served the homepage with HTTP 200 and a CSRF token. |
+| Recommendation request | CSRF-protected POST for `Sample Movie` returned HTTP 200 and included `Sample Sequel`. |

--- a/webapp/movies/test_views.py
+++ b/webapp/movies/test_views.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 if BASE_DIR not in sys.path:
@@ -16,6 +17,7 @@ from django.conf import settings
 from django.test import SimpleTestCase, override_settings
 
 from movies.views import get_recommender, _load_existing_store, _load_recommender
+from webapp import settings as settings_module
 
 
 class RecommenderSettingsTest(SimpleTestCase):
@@ -30,6 +32,46 @@ class RecommenderSettingsTest(SimpleTestCase):
         expected_path = Path(BASE_DIR) / "movies_10.sqlite"
 
         self.assertEqual(Path(settings.RECOMMENDER_STORE_PATH), expected_path)
+
+    def test_allowed_hosts_can_be_configured_from_environment(self):
+        with patch.dict(
+            os.environ,
+            {"DJANGO_ALLOWED_HOSTS": "127.0.0.1,preview.internal,,localhost"},
+        ):
+            self.assertEqual(
+                settings_module._env_csv("DJANGO_ALLOWED_HOSTS"),
+                ["127.0.0.1", "preview.internal", "localhost"],
+            )
+
+    def test_recommender_paths_can_be_configured_from_environment(self):
+        with patch.dict(
+            os.environ,
+            {
+                "RECOMMENDER_DATASET_PATH": "data/preview/movies_preview.csv",
+                "RECOMMENDER_STORE_PATH": "data/preview/movies_preview.sqlite",
+            },
+        ):
+            self.assertEqual(
+                settings_module._env_path(
+                    "RECOMMENDER_DATASET_PATH",
+                    Path(BASE_DIR) / "movies_10.csv",
+                ),
+                Path("data/preview/movies_preview.csv"),
+            )
+            self.assertEqual(
+                settings_module._env_path(
+                    "RECOMMENDER_STORE_PATH",
+                    Path(BASE_DIR) / "movies_10.sqlite",
+                ),
+                Path("data/preview/movies_preview.sqlite"),
+            )
+
+    def test_candidate_limit_can_be_configured_from_environment(self):
+        with patch.dict(os.environ, {"RECOMMENDER_CANDIDATE_LIMIT": "250"}):
+            self.assertEqual(
+                settings_module._env_int("RECOMMENDER_CANDIDATE_LIMIT", 500),
+                250,
+            )
 
 
 class GetRecommenderTest(SimpleTestCase):

--- a/webapp/webapp/settings.py
+++ b/webapp/webapp/settings.py
@@ -10,7 +10,36 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
+import os
 from pathlib import Path
+
+
+def _env_bool(name, default):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _env_csv(name, default=None):
+    value = os.environ.get(name)
+    if value is None:
+        return [] if default is None else default
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _env_path(name, default):
+    value = os.environ.get(name)
+    if not value:
+        return default
+    return Path(value).expanduser()
+
+
+def _env_int(name, default):
+    value = os.environ.get(name)
+    if not value:
+        return default
+    return int(value)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -21,12 +50,15 @@ REPO_ROOT = BASE_DIR.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-8+1*gr-ge32w&!u6*!#or6(=vufmd*d!jmg@=@0lvr)ad@n5vf"
+SECRET_KEY = os.environ.get(
+    "DJANGO_SECRET_KEY",
+    "django-insecure-8+1*gr-ge32w&!u6*!#or6(=vufmd*d!jmg@=@0lvr)ad@n5vf",
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = _env_bool("DJANGO_DEBUG", True)
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = _env_csv("DJANGO_ALLOWED_HOSTS")
 
 
 # Application definition
@@ -124,6 +156,12 @@ STATIC_URL = "static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Location of the reduced movie dataset used by the recommender
-RECOMMENDER_DATASET_PATH = REPO_ROOT / "movies_10.csv"
-RECOMMENDER_STORE_PATH = REPO_ROOT / "movies_10.sqlite"
-RECOMMENDER_CANDIDATE_LIMIT = 500
+RECOMMENDER_DATASET_PATH = _env_path(
+    "RECOMMENDER_DATASET_PATH",
+    REPO_ROOT / "movies_10.csv",
+)
+RECOMMENDER_STORE_PATH = _env_path(
+    "RECOMMENDER_STORE_PATH",
+    REPO_ROOT / "movies_10.sqlite",
+)
+RECOMMENDER_CANDIDATE_LIMIT = _env_int("RECOMMENDER_CANDIDATE_LIMIT", 500)


### PR DESCRIPTION
## Summary
- Adds a private VPS preview runbook for the current Django app using the bounded SQLite path.
- Makes preview/runtime settings configurable with environment variables: allowed hosts, recommender dataset/store paths, candidate limit, and dev server bind address.
- Adds focused tests for environment-based preview configuration.

## Verification
```text
$ make test && make smoke
.venv/bin/python -m pytest -q
.....................................                                    [100%]
37 passed in 4.04s
.venv/bin/python webapp/manage.py check
System check identified no issues (0 silenced).
```

Fixture artifact + recommender smoke:
```text
$ make imdb-bootstrap ARGS="--sample --output-dir data/imdb-sample"
Sample fixture is intentionally tiny and offline-only.

$ make canonical-dataset IMDB_DATA_DIR=data/imdb-sample DATASET_OUTPUT=data/preview/movies_preview DATASET_PERCENTAGE=0 DATASET_MIN_VOTES=0
Saved dataset to data/preview/movies_preview.csv
Skipped typed Parquet output: optional pyarrow/fastparquet not installed.

$ python recommender.py data/preview/movies_preview.csv "Sample Movie" --store data/preview/movies_preview.sqlite --candidate-limit 250
['Sample Sequel']
```

HTTP preview smoke on loopback:
```text
GET home: OK
POST Sample Movie includes Sample Sequel: OK
POST missing title includes dataset error: OK
```

Notes:
- Generated preview artifacts stayed under ignored `data/` paths.
- The Django dev server warns about unapplied admin/auth/session migrations in a fresh checkout; the preview search path does not use those tables. The runbook documents optional `manage.py migrate` for longer manual sessions.

Closes #30
