### PR TITLE
issue #14: add TMDB text enrichment pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ webapp/db.sqlite3
 movies_*.csv
 movies_*.parquet
 movies_*.sqlite
-data/
+/data/
 imdb-data/
 *.tsv
 *.tsv.gz

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,13 @@ PYTHON ?= $(VENV)/bin/python
 UV_CACHE_DIR ?= .uv-cache
 IMDB_DATA_DIR ?= .
 IMDB_BOOTSTRAP_DIR ?= data/imdb
+TMDB_CACHE ?= data/tmdb/tmdb_enrichment.sqlite
 DATASET_OUTPUT ?= movies_10
 DATASET_PERCENTAGE ?= 0.90
 DATASET_MIN_VOTES ?= 1000
 WEB_BIND ?= 127.0.0.1:8000
 
-.PHONY: setup test run-web smoke imdb-bootstrap canonical-dataset evaluate-recommendations clean
+.PHONY: setup test run-web smoke imdb-bootstrap canonical-dataset tmdb-enrichment evaluate-recommendations clean
 
 setup:
 	@if [ ! -x "$(VENV)/bin/python" ]; then \
@@ -45,6 +46,9 @@ imdb-bootstrap:
 
 canonical-dataset:
 	$(PYTHON) movies.py --input-dir "$(IMDB_DATA_DIR)" --percentage "$(DATASET_PERCENTAGE)" --min-votes "$(DATASET_MIN_VOTES)" --output "$(DATASET_OUTPUT)"
+
+tmdb-enrichment:
+	$(PYTHON) tmdb_enrichment.py --input "$(DATASET_OUTPUT).csv" --cache "$(TMDB_CACHE)" $(ARGS)
 
 evaluate-recommendations:
 	$(PYTHON) evaluate_recommendations.py $(ARGS)

--- a/README.md
+++ b/README.md
@@ -246,6 +246,26 @@ recorded as `missing`; rows that fail available title/year sanity checks are
 recorded as `ambiguous` rather than guessed. The web app and recommendation CLI
 do not call TMDB at request time.
 
+TMDB API references:
+
+- TMDB API docs: <https://developer.themoviedb.org/reference/intro/getting-started>
+- Configuration details: <https://developer.themoviedb.org/reference/configuration-details>
+- Logos and attribution: <https://www.themoviedb.org/about/logos-attribution>
+
+This repository currently uses TMDB only for offline text/data enrichment. If
+poster or image work is added later, use TMDB's configuration endpoint to resolve
+the current image base URLs and supported sizes instead of hardcoding image URL
+patterns.
+
+### TMDB attribution
+
+Every application surface that displays TMDB-sourced data or images must include
+TMDB attribution and follow TMDB's logo/brand guidance. Use the official TMDB
+logos from their attribution page where UI space allows, and include this notice
+prominently in the application or related documentation:
+
+> This product uses the TMDB API but is not endorsed or certified by TMDB.
+
 Run CLI recommendations:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -208,6 +208,44 @@ You can override the artifact prefix and filter settings:
 make canonical-dataset IMDB_DATA_DIR=/path/to/imdb-tsvs DATASET_OUTPUT=movies_10 DATASET_PERCENTAGE=0.90 DATASET_MIN_VOTES=1000
 ```
 
+## TMDB Text Enrichment
+
+TMDB enrichment is an offline data-pipeline step for future semantic
+recommendations. It keeps IMDb `tconst` as the canonical movie ID, maps each row
+to TMDB with API v3's IMDb external ID lookup, then stores nullable plot/theme
+fields in a local SQLite artifact keyed by `tconst`.
+
+The command reads a reduced CSV such as `movies_10.csv` and writes
+`data/tmdb/tmdb_enrichment.sqlite` by default. The `data/` directory is ignored
+by git; do not commit provider caches or API credentials.
+
+Preview the local plan without credentials or network access:
+
+```bash
+python tmdb_enrichment.py --input movies_10.csv --dry-run
+```
+
+Run live enrichment only when `TMDB_API_KEY` is set in the environment:
+
+```bash
+TMDB_API_KEY=... make tmdb-enrichment DATASET_OUTPUT=movies_10
+```
+
+Useful live options:
+
+```bash
+python tmdb_enrichment.py --input movies_10.csv --limit 25 --run-id local-smoke
+python tmdb_enrichment.py --input movies_10.csv --cache data/tmdb/tmdb_enrichment.sqlite --force
+```
+
+The cache tracks `fetched`, `missing`, `ambiguous`, and `error` statuses with
+TMDB provenance (`source=tmdb`, `source_api_version=v3`, language, fetched
+timestamp, run ID, and payload hash). Existing final-status rows are skipped by
+default so interrupted runs can resume. Rows with no TMDB movie result are
+recorded as `missing`; rows that fail available title/year sanity checks are
+recorded as `ambiguous` rather than guessed. The web app and recommendation CLI
+do not call TMDB at request time.
+
 Run CLI recommendations:
 
 ```bash

--- a/src/movie_recommender/cli/tmdb_enrichment.py
+++ b/src/movie_recommender/cli/tmdb_enrichment.py
@@ -1,0 +1,9 @@
+"""Command line entrypoint for TMDB enrichment helpers."""
+
+from movie_recommender.data.tmdb_enrichment import main
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/movie_recommender/data/tmdb_enrichment.py
+++ b/src/movie_recommender/data/tmdb_enrichment.py
@@ -1,0 +1,577 @@
+"""Offline TMDB text enrichment keyed by canonical IMDb IDs."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+
+DEFAULT_CACHE_PATH = Path("data/tmdb/tmdb_enrichment.sqlite")
+DEFAULT_LANGUAGE = "en-US"
+SOURCE = "tmdb"
+SOURCE_API_VERSION = "v3"
+SKIP_STATUSES = {"fetched", "missing", "ambiguous"}
+
+
+@dataclass(frozen=True)
+class TMDBEnrichmentResult:
+    """Result for one enrichment attempt."""
+
+    tconst: str
+    status: str
+    tmdb_id: int | None = None
+    imdb_id: str | None = None
+    title: str | None = None
+    original_title: str | None = None
+    release_date: str | None = None
+    original_language: str | None = None
+    overview: str | None = None
+    tagline: str | None = None
+    keywords: tuple[str, ...] = ()
+    genres: tuple[str, ...] = ()
+    error: str | None = None
+
+
+class TMDBClient:
+    """Small TMDB API v3 client for offline enrichment jobs."""
+
+    BASE_URL = "https://api.themoviedb.org/3"
+
+    def __init__(
+        self,
+        api_key: str,
+        language: str = DEFAULT_LANGUAGE,
+        timeout_seconds: int = 20,
+        max_retries: int = 3,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self.api_key = api_key
+        self.language = language
+        self.timeout_seconds = timeout_seconds
+        self.max_retries = max_retries
+        self.sleep = sleep
+
+    def _request(self, path: str, params: dict[str, object] | None = None) -> dict[str, object]:
+        query = dict(params or {})
+        query["api_key"] = self.api_key
+        url = f"{self.BASE_URL}{path}?{urlencode(query)}"
+        request = Request(url, headers={"Accept": "application/json"})
+
+        attempts = 0
+        while True:
+            try:
+                with urlopen(request, timeout=self.timeout_seconds) as response:
+                    return json.loads(response.read().decode("utf-8"))
+            except HTTPError as exc:
+                attempts += 1
+                if exc.code == 429 and attempts <= self.max_retries:
+                    retry_after = exc.headers.get("Retry-After") if exc.headers else None
+                    delay = _parse_retry_after(retry_after, attempts)
+                    self.sleep(delay)
+                    continue
+                raise RuntimeError(
+                    f"TMDB request failed with HTTP {exc.code}: {self.BASE_URL}{path}"
+                ) from exc
+            except (TimeoutError, URLError) as exc:
+                attempts += 1
+                if attempts <= self.max_retries:
+                    self.sleep(float(attempts))
+                    continue
+                raise RuntimeError(f"TMDB request failed: {exc}") from exc
+
+    def find_by_imdb_id(self, tconst: str) -> list[dict[str, object]]:
+        """Map an IMDb title ID to TMDB movie results."""
+        data = self._request(
+            f"/find/{quote(tconst)}",
+            {"external_source": "imdb_id"},
+        )
+        movie_results = data.get("movie_results") or []
+        if not isinstance(movie_results, list):
+            return []
+        return [result for result in movie_results if isinstance(result, dict)]
+
+    def movie_details(self, tmdb_id: int) -> dict[str, object]:
+        """Fetch TMDB movie details plus keyword names."""
+        return self._request(
+            f"/movie/{tmdb_id}",
+            {"append_to_response": "keywords", "language": self.language},
+        )
+
+
+class TMDBEnrichmentCache:
+    """SQLite cache for resumable TMDB enrichment runs."""
+
+    def __init__(
+        self,
+        path: str | Path = DEFAULT_CACHE_PATH,
+        source_language: str = DEFAULT_LANGUAGE,
+    ) -> None:
+        self.path = Path(path)
+        self.source_language = source_language
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _ensure_schema(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tmdb_enrichment (
+                    tconst TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    source_api_version TEXT NOT NULL,
+                    source_language TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    error TEXT,
+                    tmdb_id INTEGER,
+                    imdb_id TEXT,
+                    title TEXT,
+                    original_title TEXT,
+                    release_date TEXT,
+                    original_language TEXT,
+                    overview TEXT,
+                    tagline TEXT,
+                    keywords_json TEXT NOT NULL DEFAULT '[]',
+                    genres_json TEXT NOT NULL DEFAULT '[]',
+                    combined_text TEXT NOT NULL DEFAULT '',
+                    fetched_at TEXT NOT NULL,
+                    payload_hash TEXT,
+                    run_id TEXT,
+                    PRIMARY KEY (
+                        tconst,
+                        source,
+                        source_api_version,
+                        source_language
+                    )
+                )
+                """
+            )
+
+    def get(self, tconst: str) -> dict[str, object] | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT * FROM tmdb_enrichment
+                WHERE tconst = ?
+                  AND source = ?
+                  AND source_api_version = ?
+                  AND source_language = ?
+                """,
+                (tconst, SOURCE, SOURCE_API_VERSION, self.source_language),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def upsert(self, result: TMDBEnrichmentResult, run_id: str | None = None) -> None:
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        keywords = list(result.keywords)
+        genres = list(result.genres)
+        combined_text = _combined_text(result.overview, result.tagline, keywords, genres)
+        payload_hash = _payload_hash(
+            {
+                "status": result.status,
+                "tmdb_id": result.tmdb_id,
+                "imdb_id": result.imdb_id,
+                "overview": result.overview,
+                "tagline": result.tagline,
+                "keywords": keywords,
+                "genres": genres,
+                "error": result.error,
+            }
+        )
+
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO tmdb_enrichment (
+                    tconst,
+                    source,
+                    source_api_version,
+                    source_language,
+                    status,
+                    error,
+                    tmdb_id,
+                    imdb_id,
+                    title,
+                    original_title,
+                    release_date,
+                    original_language,
+                    overview,
+                    tagline,
+                    keywords_json,
+                    genres_json,
+                    combined_text,
+                    fetched_at,
+                    payload_hash,
+                    run_id
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (
+                    tconst,
+                    source,
+                    source_api_version,
+                    source_language
+                ) DO UPDATE SET
+                    status = excluded.status,
+                    error = excluded.error,
+                    tmdb_id = excluded.tmdb_id,
+                    imdb_id = excluded.imdb_id,
+                    title = excluded.title,
+                    original_title = excluded.original_title,
+                    release_date = excluded.release_date,
+                    original_language = excluded.original_language,
+                    overview = excluded.overview,
+                    tagline = excluded.tagline,
+                    keywords_json = excluded.keywords_json,
+                    genres_json = excluded.genres_json,
+                    combined_text = excluded.combined_text,
+                    fetched_at = excluded.fetched_at,
+                    payload_hash = excluded.payload_hash,
+                    run_id = excluded.run_id
+                """,
+                (
+                    result.tconst,
+                    SOURCE,
+                    SOURCE_API_VERSION,
+                    self.source_language,
+                    result.status,
+                    result.error,
+                    result.tmdb_id,
+                    result.imdb_id,
+                    result.title,
+                    result.original_title,
+                    result.release_date,
+                    result.original_language,
+                    result.overview,
+                    result.tagline,
+                    json.dumps(keywords),
+                    json.dumps(genres),
+                    combined_text,
+                    now,
+                    payload_hash,
+                    run_id,
+                ),
+            )
+
+    def list_rows(self) -> list[dict[str, object]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM tmdb_enrichment ORDER BY tconst"
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+
+class TMDBMovieEnricher:
+    """Enrich one canonical movie row through TMDB."""
+
+    def __init__(
+        self,
+        client: TMDBClient,
+        cache: TMDBEnrichmentCache,
+        run_id: str | None = None,
+    ) -> None:
+        self.client = client
+        self.cache = cache
+        self.run_id = run_id
+
+    def enrich_movie(
+        self,
+        row: dict[str, object],
+        force: bool = False,
+    ) -> TMDBEnrichmentResult:
+        tconst = str(row.get("tconst") or "").strip()
+        if not tconst:
+            raise ValueError("input row is missing tconst")
+
+        cached = self.cache.get(tconst)
+        if cached and not force and cached["status"] in SKIP_STATUSES:
+            return TMDBEnrichmentResult(tconst=tconst, status="skipped")
+
+        try:
+            candidates = self.client.find_by_imdb_id(tconst)
+            selected = _select_candidate(candidates, row)
+            if not candidates:
+                result = TMDBEnrichmentResult(tconst=tconst, status="missing")
+            elif selected is None:
+                result = TMDBEnrichmentResult(
+                    tconst=tconst,
+                    status="ambiguous",
+                    error="TMDB movie result failed title/year sanity checks",
+                )
+            else:
+                details = self.client.movie_details(int(selected["id"]))
+                result = _result_from_details(tconst, details, selected)
+        except Exception as exc:
+            result = TMDBEnrichmentResult(tconst=tconst, status="error", error=str(exc))
+
+        self.cache.upsert(result, run_id=self.run_id)
+        return result
+
+
+def enrich_csv(
+    input_path: str | Path,
+    cache_path: str | Path = DEFAULT_CACHE_PATH,
+    api_key: str | None = None,
+    limit: int | None = None,
+    force: bool = False,
+    run_id: str | None = None,
+    language: str = DEFAULT_LANGUAGE,
+    output=sys.stdout,
+) -> dict[str, int]:
+    """Enrich rows from a reduced CSV artifact and return status counts."""
+    if not api_key:
+        raise ValueError("TMDB_API_KEY is required for live TMDB enrichment")
+
+    rows = _read_input_rows(input_path)
+    if limit is not None:
+        rows = rows[:limit]
+
+    cache = TMDBEnrichmentCache(cache_path, source_language=language)
+    client = TMDBClient(api_key, language=language)
+    enricher = TMDBMovieEnricher(client, cache, run_id=run_id)
+    counts: dict[str, int] = {}
+    for row in rows:
+        result = enricher.enrich_movie(row, force=force)
+        counts[result.status] = counts.get(result.status, 0) + 1
+        print(f"{result.tconst}\t{result.status}", file=output)
+    return counts
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Enrich a reduced movie CSV with TMDB plot/theme text."
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Reduced CSV artifact containing canonical tconst values.",
+    )
+    parser.add_argument(
+        "--cache",
+        type=Path,
+        default=DEFAULT_CACHE_PATH,
+        help=f"SQLite cache/output path. Default: {DEFAULT_CACHE_PATH}",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Maximum input rows to process.",
+    )
+    parser.add_argument(
+        "--language",
+        default=DEFAULT_LANGUAGE,
+        help=f"TMDB source language. Default: {DEFAULT_LANGUAGE}",
+    )
+    parser.add_argument(
+        "--run-id",
+        help="Optional operator-provided run/config identifier.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Refresh rows even when a final cached status already exists.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate input and print the local plan without calling TMDB.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.limit is not None and args.limit < 1:
+        parser.error("--limit must be at least 1")
+
+    rows = _read_input_rows(args.input)
+    selected_rows = rows[: args.limit] if args.limit is not None else rows
+    if args.dry_run:
+        print(f"Would enrich {len(selected_rows)} movie rows from {args.input}.")
+        print(f"Would store TMDB cache/output at {args.cache}.")
+        print("No TMDB requests made.")
+        return 0
+
+    api_key = os.environ.get("TMDB_API_KEY")
+    if not api_key:
+        parser.error("TMDB_API_KEY is required for live TMDB enrichment")
+
+    counts = enrich_csv(
+        args.input,
+        cache_path=args.cache,
+        api_key=api_key,
+        limit=args.limit,
+        force=args.force,
+        run_id=args.run_id,
+        language=args.language,
+    )
+    print("Summary: " + ", ".join(f"{key}={counts[key]}" for key in sorted(counts)))
+    return 0
+
+
+def _read_input_rows(input_path: str | Path) -> list[dict[str, object]]:
+    path = Path(input_path)
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if not reader.fieldnames or "tconst" not in reader.fieldnames:
+            raise ValueError("input CSV must include a tconst column")
+        return [dict(row) for row in reader]
+
+
+def _parse_retry_after(value: str | None, attempt: int) -> float:
+    if value:
+        try:
+            return max(0.0, float(value))
+        except ValueError:
+            pass
+    return float(attempt)
+
+
+def _select_candidate(
+    candidates: list[dict[str, object]],
+    row: dict[str, object],
+) -> dict[str, object] | None:
+    if not candidates:
+        return None
+
+    input_title = _input_title(row)
+    input_year = _input_year(row)
+    if not input_title and not input_year:
+        return candidates[0] if len(candidates) == 1 else None
+
+    sane_candidates = [
+        candidate
+        for candidate in candidates
+        if _title_matches(input_title, candidate)
+        and _year_matches(input_year, candidate.get("release_date"))
+    ]
+    return sane_candidates[0] if len(sane_candidates) == 1 else None
+
+
+def _input_title(row: dict[str, object]) -> str | None:
+    for key in ("primary_title", "primaryTitle", "title"):
+        value = str(row.get(key) or "").strip()
+        if value:
+            return re.sub(r"\s+\(tt\d+\)$", "", value)
+    return None
+
+
+def _input_year(row: dict[str, object]) -> str | None:
+    for key in ("startYear", "release_year", "year"):
+        value = str(row.get(key) or "").strip()
+        if re.fullmatch(r"\d{4}", value):
+            return value
+    return None
+
+
+def _title_matches(input_title: str | None, candidate: dict[str, object]) -> bool:
+    if not input_title:
+        return True
+    normalized_input = _normalize_title(input_title)
+    candidate_titles = [
+        _normalize_title(str(candidate.get("title") or "")),
+        _normalize_title(str(candidate.get("original_title") or "")),
+    ]
+    return normalized_input in candidate_titles
+
+
+def _year_matches(input_year: str | None, release_date: object) -> bool:
+    if not input_year:
+        return True
+    release_year = str(release_date or "")[:4]
+    return bool(re.fullmatch(r"\d{4}", release_year)) and release_year == input_year
+
+
+def _normalize_title(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def _result_from_details(
+    tconst: str,
+    details: dict[str, object],
+    selected: dict[str, object],
+) -> TMDBEnrichmentResult:
+    keywords_data = details.get("keywords")
+    keyword_rows: Iterable[object]
+    if isinstance(keywords_data, dict):
+        keyword_rows = keywords_data.get("keywords") or keywords_data.get("results") or []
+    else:
+        keyword_rows = []
+
+    return TMDBEnrichmentResult(
+        tconst=tconst,
+        status="fetched",
+        tmdb_id=_int_or_none(details.get("id") or selected.get("id")),
+        imdb_id=_str_or_none(details.get("imdb_id")) or tconst,
+        title=_str_or_none(details.get("title") or selected.get("title")),
+        original_title=_str_or_none(
+            details.get("original_title") or selected.get("original_title")
+        ),
+        release_date=_str_or_none(details.get("release_date") or selected.get("release_date")),
+        original_language=_str_or_none(details.get("original_language")),
+        overview=_str_or_none(details.get("overview")),
+        tagline=_str_or_none(details.get("tagline")),
+        keywords=tuple(_names(keyword_rows)),
+        genres=tuple(_names(details.get("genres") or [])),
+    )
+
+
+def _names(rows: Iterable[object]) -> list[str]:
+    names = []
+    for row in rows:
+        if isinstance(row, dict):
+            name = str(row.get("name") or "").strip()
+            if name:
+                names.append(name)
+    return names
+
+
+def _str_or_none(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _int_or_none(value: object) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _combined_text(
+    overview: str | None,
+    tagline: str | None,
+    keywords: list[str],
+    genres: list[str],
+) -> str:
+    parts = [overview or "", tagline or "", " ".join(keywords), " ".join(genres)]
+    return "\n".join(part for part in parts if part.strip())
+
+
+def _payload_hash(payload: dict[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/movie_recommender/data/tmdb_enrichment.py
+++ b/src/movie_recommender/data/tmdb_enrichment.py
@@ -341,7 +341,7 @@ class TMDBMovieEnricher:
         except Exception as exc:
             result = TMDBEnrichmentResult(tconst=tconst, status="error", error=str(exc))
 
-        if result.status == "error" and cached and cached["status"] == "fetched":
+        if result.status in {"error", "missing"} and cached and cached["status"] == "fetched":
             return result
 
         self.cache.upsert(result, run_id=self.run_id)

--- a/src/movie_recommender/data/tmdb_enrichment.py
+++ b/src/movie_recommender/data/tmdb_enrichment.py
@@ -79,7 +79,16 @@ class TMDBClient:
         while True:
             try:
                 with urlopen(request, timeout=self.timeout_seconds) as response:
-                    return json.loads(response.read().decode("utf-8"))
+                    payload = json.loads(response.read().decode("utf-8"))
+                    if not isinstance(payload, dict):
+                        raise TMDBRequestError(
+                            f"TMDB response was not a JSON object: {self.BASE_URL}{path}"
+                        )
+                    return payload
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise TMDBRequestError(
+                    f"TMDB response was not valid JSON: {self.BASE_URL}{path}"
+                ) from exc
             except HTTPError as exc:
                 attempts += 1
                 if exc.code == 429 and attempts <= self.max_retries:
@@ -326,6 +335,9 @@ class TMDBMovieEnricher:
             raise
         except Exception as exc:
             result = TMDBEnrichmentResult(tconst=tconst, status="error", error=str(exc))
+
+        if result.status == "error" and cached and cached["status"] == "fetched":
+            return result
 
         self.cache.upsert(result, run_id=self.run_id)
         return result

--- a/src/movie_recommender/data/tmdb_enrichment.py
+++ b/src/movie_recommender/data/tmdb_enrichment.py
@@ -341,7 +341,11 @@ class TMDBMovieEnricher:
         except Exception as exc:
             result = TMDBEnrichmentResult(tconst=tconst, status="error", error=str(exc))
 
-        if result.status in {"error", "missing"} and cached and cached["status"] == "fetched":
+        if (
+            result.status in {"ambiguous", "error", "missing"}
+            and cached
+            and cached["status"] == "fetched"
+        ):
             return result
 
         self.cache.upsert(result, run_id=self.run_id)

--- a/src/movie_recommender/data/tmdb_enrichment.py
+++ b/src/movie_recommender/data/tmdb_enrichment.py
@@ -118,8 +118,8 @@ class TMDBClient:
         if not isinstance(movie_results, list):
             raise TMDBRequestError("TMDB find response movie_results was not a list")
         valid_results = [result for result in movie_results if isinstance(result, dict)]
-        if movie_results and not valid_results:
-            raise TMDBRequestError("TMDB find response had no valid movie results")
+        if len(valid_results) != len(movie_results):
+            raise TMDBRequestError("TMDB find response had malformed movie results")
         return valid_results
 
     def movie_details(self, tmdb_id: int) -> dict[str, object]:
@@ -479,6 +479,8 @@ def _select_candidate(
 ) -> dict[str, object] | None:
     if not candidates:
         return None
+    if len(candidates) == 1:
+        return candidates[0]
 
     input_title = _input_title(row)
     input_year = _input_year(row)

--- a/src/movie_recommender/data/tmdb_enrichment.py
+++ b/src/movie_recommender/data/tmdb_enrichment.py
@@ -112,10 +112,15 @@ class TMDBClient:
             f"/find/{quote(tconst)}",
             {"external_source": "imdb_id"},
         )
-        movie_results = data.get("movie_results") or []
+        movie_results = data.get("movie_results")
+        if movie_results is None:
+            raise TMDBRequestError("TMDB find response missing movie_results")
         if not isinstance(movie_results, list):
-            return []
-        return [result for result in movie_results if isinstance(result, dict)]
+            raise TMDBRequestError("TMDB find response movie_results was not a list")
+        valid_results = [result for result in movie_results if isinstance(result, dict)]
+        if movie_results and not valid_results:
+            raise TMDBRequestError("TMDB find response had no valid movie results")
+        return valid_results
 
     def movie_details(self, tmdb_id: int) -> dict[str, object]:
         """Fetch TMDB movie details plus keyword names."""

--- a/src/movie_recommender/data/tmdb_enrichment.py
+++ b/src/movie_recommender/data/tmdb_enrichment.py
@@ -46,6 +46,10 @@ class TMDBEnrichmentResult:
     error: str | None = None
 
 
+class TMDBRequestError(RuntimeError):
+    """Run-level TMDB request failure."""
+
+
 class TMDBClient:
     """Small TMDB API v3 client for offline enrichment jobs."""
 
@@ -83,7 +87,7 @@ class TMDBClient:
                     delay = _parse_retry_after(retry_after, attempts)
                     self.sleep(delay)
                     continue
-                raise RuntimeError(
+                raise TMDBRequestError(
                     f"TMDB request failed with HTTP {exc.code}: {self.BASE_URL}{path}"
                 ) from exc
             except (TimeoutError, URLError) as exc:
@@ -91,7 +95,7 @@ class TMDBClient:
                 if attempts <= self.max_retries:
                     self.sleep(float(attempts))
                     continue
-                raise RuntimeError(f"TMDB request failed: {exc}") from exc
+                raise TMDBRequestError(f"TMDB request failed: {exc}") from exc
 
     def find_by_imdb_id(self, tconst: str) -> list[dict[str, object]]:
         """Map an IMDb title ID to TMDB movie results."""
@@ -318,6 +322,8 @@ class TMDBMovieEnricher:
             else:
                 details = self.client.movie_details(int(selected["id"]))
                 result = _result_from_details(tconst, details, selected)
+        except TMDBRequestError:
+            raise
         except Exception as exc:
             result = TMDBEnrichmentResult(tconst=tconst, status="error", error=str(exc))
 
@@ -416,15 +422,18 @@ def main(argv: list[str] | None = None) -> int:
     if not api_key:
         parser.error("TMDB_API_KEY is required for live TMDB enrichment")
 
-    counts = enrich_csv(
-        args.input,
-        cache_path=args.cache,
-        api_key=api_key,
-        limit=args.limit,
-        force=args.force,
-        run_id=args.run_id,
-        language=args.language,
-    )
+    try:
+        counts = enrich_csv(
+            args.input,
+            cache_path=args.cache,
+            api_key=api_key,
+            limit=args.limit,
+            force=args.force,
+            run_id=args.run_id,
+            language=args.language,
+        )
+    except TMDBRequestError as exc:
+        parser.exit(1, f"tmdb_enrichment.py: error: {exc}\n")
     print("Summary: " + ", ".join(f"{key}={counts[key]}" for key in sorted(counts)))
     return 0
 

--- a/tests/data/test_tmdb_enrichment.py
+++ b/tests/data/test_tmdb_enrichment.py
@@ -214,6 +214,22 @@ class TMDBEnrichmentTest(unittest.TestCase):
             with self.assertRaises(TMDBRequestError):
                 client.find_by_imdb_id("tt1375666")
 
+    def test_malformed_find_movie_results_are_request_failures(self) -> None:
+        payloads = [
+            {"movie_results": {"id": 27205}},
+            {"movie_results": ["not-a-result"]},
+        ]
+
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                with patch(
+                    "movie_recommender.data.tmdb_enrichment.urlopen",
+                    return_value=FakeTMDBResponse(payload),
+                ):
+                    client = TMDBClient("test-key", max_retries=0)
+                    with self.assertRaises(TMDBRequestError):
+                        client.find_by_imdb_id("tt1375666")
+
     def test_error_status_is_retried_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             cache = TMDBEnrichmentCache(Path(tmp) / "tmdb.sqlite")

--- a/tests/data/test_tmdb_enrichment.py
+++ b/tests/data/test_tmdb_enrichment.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import csv
 import json
 import os
+from contextlib import redirect_stderr
+from io import StringIO
 from pathlib import Path
 import sqlite3
 import subprocess
@@ -19,6 +21,9 @@ from movie_recommender.data.tmdb_enrichment import (
     TMDBEnrichmentCache,
     TMDBEnrichmentResult,
     TMDBMovieEnricher,
+    TMDBRequestError,
+    enrich_csv,
+    main,
 )
 
 
@@ -195,6 +200,79 @@ class TMDBEnrichmentTest(unittest.TestCase):
             result = enricher.enrich_movie({"tconst": "tt0000001", "primary_title": "Sample Movie"})
 
         self.assertEqual(result.status, "missing")
+
+    def test_tmdb_request_failure_aborts_csv_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            input_path = Path(tmp) / "movies.csv"
+            cache_path = Path(tmp) / "tmdb.sqlite"
+            with input_path.open("w", encoding="utf-8", newline="") as handle:
+                writer = csv.DictWriter(handle, fieldnames=["tconst", "primary_title"])
+                writer.writeheader()
+                writer.writerow({"tconst": "tt0000001", "primary_title": "Sample Movie"})
+
+            with patch.object(
+                TMDBClient,
+                "find_by_imdb_id",
+                side_effect=TMDBRequestError("TMDB request failed with HTTP 401"),
+            ):
+                with self.assertRaises(TMDBRequestError):
+                    enrich_csv(input_path, cache_path=cache_path, api_key="bad-key")
+
+            rows = TMDBEnrichmentCache(cache_path).list_rows()
+
+        self.assertEqual(rows, [])
+
+    def test_cli_exits_nonzero_on_tmdb_request_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            input_path = Path(tmp) / "movies.csv"
+            with input_path.open("w", encoding="utf-8", newline="") as handle:
+                writer = csv.DictWriter(handle, fieldnames=["tconst", "primary_title"])
+                writer.writeheader()
+                writer.writerow({"tconst": "tt0000001", "primary_title": "Sample Movie"})
+
+            stderr = StringIO()
+            with patch.dict(os.environ, {"TMDB_API_KEY": "bad-key"}):
+                with patch(
+                    "movie_recommender.data.tmdb_enrichment.enrich_csv",
+                    side_effect=TMDBRequestError("TMDB request failed with HTTP 401"),
+                ):
+                    with redirect_stderr(stderr):
+                        with self.assertRaises(SystemExit) as exit_error:
+                            main(["--input", str(input_path)])
+
+        self.assertEqual(exit_error.exception.code, 1)
+        self.assertIn("TMDB request failed with HTTP 401", stderr.getvalue())
+
+    def test_force_refresh_failure_preserves_existing_fetched_row(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = TMDBEnrichmentCache(Path(tmp) / "tmdb.sqlite")
+            cache.upsert(
+                TMDBEnrichmentResult(
+                    tconst="tt1375666",
+                    status="fetched",
+                    tmdb_id=27205,
+                    overview="Existing overview",
+                    keywords=("dream",),
+                    genres=("Action",),
+                )
+            )
+            client = FakeTMDBClient({"tt1375666": []})
+            client.find_by_imdb_id = Mock(
+                side_effect=TMDBRequestError("TMDB request failed")
+            )
+            enricher = TMDBMovieEnricher(client, cache)
+
+            with self.assertRaises(TMDBRequestError):
+                enricher.enrich_movie(
+                    {"tconst": "tt1375666", "primary_title": "Inception"},
+                    force=True,
+                )
+
+            row = cache.get("tt1375666")
+
+        self.assertEqual(row["status"], "fetched")
+        self.assertEqual(row["overview"], "Existing overview")
+        self.assertEqual(json.loads(row["keywords_json"]), ["dream"])
 
     def test_cli_dry_run_does_not_require_api_key(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]

--- a/tests/data/test_tmdb_enrichment.py
+++ b/tests/data/test_tmdb_enrichment.py
@@ -148,6 +148,12 @@ class TMDBEnrichmentTest(unittest.TestCase):
                             "title": "Wrong Movie",
                             "original_title": "Wrong Movie",
                             "release_date": "2001-01-01",
+                        },
+                        {
+                            "id": 2,
+                            "title": "Another Wrong Movie",
+                            "original_title": "Another Wrong Movie",
+                            "release_date": "2002-01-01",
                         }
                     ],
                 }
@@ -218,6 +224,7 @@ class TMDBEnrichmentTest(unittest.TestCase):
         payloads = [
             {"movie_results": {"id": 27205}},
             {"movie_results": ["not-a-result"]},
+            {"movie_results": [{"id": 27205}, "not-a-result"]},
         ]
 
         for payload in payloads:
@@ -229,6 +236,40 @@ class TMDBEnrichmentTest(unittest.TestCase):
                     client = TMDBClient("test-key", max_retries=0)
                     with self.assertRaises(TMDBRequestError):
                         client.find_by_imdb_id("tt1375666")
+
+    def test_unique_imdb_find_result_is_authoritative_despite_title_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = TMDBEnrichmentCache(Path(tmp) / "tmdb.sqlite")
+            client = FakeTMDBClient(
+                {
+                    "tt1375666": [
+                        {
+                            "id": 27205,
+                            "title": "Origine",
+                            "original_title": "Origine",
+                            "release_date": "2011-01-01",
+                        }
+                    ]
+                },
+                {
+                    27205: {
+                        "id": 27205,
+                        "imdb_id": "tt1375666",
+                        "title": "Origine",
+                        "original_title": "Origine",
+                        "release_date": "2011-01-01",
+                    }
+                },
+            )
+            enricher = TMDBMovieEnricher(client, cache)
+
+            result = enricher.enrich_movie(
+                {"tconst": "tt1375666", "primary_title": "Inception", "startYear": "2010"}
+            )
+
+        self.assertEqual(result.status, "fetched")
+        self.assertEqual(result.tmdb_id, 27205)
+        self.assertEqual(client.details_calls, [27205])
 
     def test_error_status_is_retried_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/data/test_tmdb_enrichment.py
+++ b/tests/data/test_tmdb_enrichment.py
@@ -392,6 +392,33 @@ class TMDBEnrichmentTest(unittest.TestCase):
         self.assertEqual(row["overview"], "Existing overview")
         self.assertEqual(json.loads(row["keywords_json"]), ["dream"])
 
+    def test_force_refresh_missing_preserves_existing_fetched_row(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = TMDBEnrichmentCache(Path(tmp) / "tmdb.sqlite")
+            cache.upsert(
+                TMDBEnrichmentResult(
+                    tconst="tt1375666",
+                    status="fetched",
+                    tmdb_id=27205,
+                    overview="Existing overview",
+                    keywords=("dream",),
+                    genres=("Action",),
+                )
+            )
+            client = FakeTMDBClient({"tt1375666": []})
+            enricher = TMDBMovieEnricher(client, cache)
+
+            result = enricher.enrich_movie(
+                {"tconst": "tt1375666", "primary_title": "Inception"},
+                force=True,
+            )
+            row = cache.get("tt1375666")
+
+        self.assertEqual(result.status, "missing")
+        self.assertEqual(row["status"], "fetched")
+        self.assertEqual(row["overview"], "Existing overview")
+        self.assertEqual(json.loads(row["keywords_json"]), ["dream"])
+
     def test_cli_dry_run_does_not_require_api_key(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/data/test_tmdb_enrichment.py
+++ b/tests/data/test_tmdb_enrichment.py
@@ -419,6 +419,50 @@ class TMDBEnrichmentTest(unittest.TestCase):
         self.assertEqual(row["overview"], "Existing overview")
         self.assertEqual(json.loads(row["keywords_json"]), ["dream"])
 
+    def test_force_refresh_ambiguous_preserves_existing_fetched_row(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = TMDBEnrichmentCache(Path(tmp) / "tmdb.sqlite")
+            cache.upsert(
+                TMDBEnrichmentResult(
+                    tconst="tt1375666",
+                    status="fetched",
+                    tmdb_id=27205,
+                    overview="Existing overview",
+                    keywords=("dream",),
+                    genres=("Action",),
+                )
+            )
+            client = FakeTMDBClient(
+                {
+                    "tt1375666": [
+                        {
+                            "id": 1,
+                            "title": "Wrong Movie",
+                            "original_title": "Wrong Movie",
+                            "release_date": "2001-01-01",
+                        },
+                        {
+                            "id": 2,
+                            "title": "Another Wrong Movie",
+                            "original_title": "Another Wrong Movie",
+                            "release_date": "2002-01-01",
+                        },
+                    ]
+                }
+            )
+            enricher = TMDBMovieEnricher(client, cache)
+
+            result = enricher.enrich_movie(
+                {"tconst": "tt1375666", "primary_title": "Inception"},
+                force=True,
+            )
+            row = cache.get("tt1375666")
+
+        self.assertEqual(result.status, "ambiguous")
+        self.assertEqual(row["status"], "fetched")
+        self.assertEqual(row["overview"], "Existing overview")
+        self.assertEqual(json.loads(row["keywords_json"]), ["dream"])
+
     def test_cli_dry_run_does_not_require_api_key(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/data/test_tmdb_enrichment.py
+++ b/tests/data/test_tmdb_enrichment.py
@@ -42,6 +42,21 @@ class FakeTMDBResponse:
         return json.dumps(self.payload).encode("utf-8")
 
 
+class RawTMDBResponse:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+        self.headers = {}
+
+    def __enter__(self) -> "RawTMDBResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.body
+
+
 class FakeTMDBClient:
     def __init__(
         self,
@@ -190,6 +205,15 @@ class TMDBEnrichmentTest(unittest.TestCase):
 
         self.assertNotIn("secret-api-key", str(error.exception))
 
+    def test_malformed_json_response_is_request_failure(self) -> None:
+        with patch(
+            "movie_recommender.data.tmdb_enrichment.urlopen",
+            return_value=RawTMDBResponse(b""),
+        ):
+            client = TMDBClient("test-key", max_retries=0)
+            with self.assertRaises(TMDBRequestError):
+                client.find_by_imdb_id("tt1375666")
+
     def test_error_status_is_retried_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             cache = TMDBEnrichmentCache(Path(tmp) / "tmdb.sqlite")
@@ -270,6 +294,43 @@ class TMDBEnrichmentTest(unittest.TestCase):
 
             row = cache.get("tt1375666")
 
+        self.assertEqual(row["status"], "fetched")
+        self.assertEqual(row["overview"], "Existing overview")
+        self.assertEqual(json.loads(row["keywords_json"]), ["dream"])
+
+    def test_force_refresh_row_error_preserves_existing_fetched_row(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = TMDBEnrichmentCache(Path(tmp) / "tmdb.sqlite")
+            cache.upsert(
+                TMDBEnrichmentResult(
+                    tconst="tt1375666",
+                    status="fetched",
+                    tmdb_id=27205,
+                    overview="Existing overview",
+                    keywords=("dream",),
+                    genres=("Action",),
+                )
+            )
+            client = FakeTMDBClient(
+                {
+                    "tt1375666": [
+                        {
+                            "title": "Inception",
+                            "original_title": "Inception",
+                            "release_date": "2010-07-15",
+                        }
+                    ]
+                }
+            )
+            enricher = TMDBMovieEnricher(client, cache)
+
+            result = enricher.enrich_movie(
+                {"tconst": "tt1375666", "primary_title": "Inception"},
+                force=True,
+            )
+            row = cache.get("tt1375666")
+
+        self.assertEqual(result.status, "error")
         self.assertEqual(row["status"], "fetched")
         self.assertEqual(row["overview"], "Existing overview")
         self.assertEqual(json.loads(row["keywords_json"]), ["dream"])

--- a/tests/data/test_tmdb_enrichment.py
+++ b/tests/data/test_tmdb_enrichment.py
@@ -1,0 +1,258 @@
+"""Tests for offline TMDB enrichment helpers."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from pathlib import Path
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+from urllib.error import HTTPError
+
+from movie_recommender.data.tmdb_enrichment import (
+    TMDBClient,
+    TMDBEnrichmentCache,
+    TMDBEnrichmentResult,
+    TMDBMovieEnricher,
+)
+
+
+class FakeTMDBResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+        self.headers = {}
+
+    def __enter__(self) -> "FakeTMDBResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class FakeTMDBClient:
+    def __init__(
+        self,
+        find_results: dict[str, list[dict[str, object]]],
+        details: dict[int, dict[str, object]] | None = None,
+    ) -> None:
+        self.find_results = find_results
+        self.details = details or {}
+        self.details_calls: list[int] = []
+
+    def find_by_imdb_id(self, tconst: str) -> list[dict[str, object]]:
+        return self.find_results[tconst]
+
+    def movie_details(self, tmdb_id: int) -> dict[str, object]:
+        self.details_calls.append(tmdb_id)
+        return self.details[tmdb_id]
+
+
+class TMDBEnrichmentTest(unittest.TestCase):
+    def test_enricher_fetches_details_and_upserts_by_tconst(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "tmdb.sqlite"
+            cache = TMDBEnrichmentCache(cache_path)
+            client = FakeTMDBClient(
+                {
+                    "tt1375666": [
+                        {
+                            "id": 27205,
+                            "title": "Inception",
+                            "original_title": "Inception",
+                            "release_date": "2010-07-15",
+                        }
+                    ]
+                },
+                {
+                    27205: {
+                        "id": 27205,
+                        "imdb_id": "tt1375666",
+                        "title": "Inception",
+                        "original_title": "Inception",
+                        "release_date": "2010-07-15",
+                        "original_language": "en",
+                        "overview": "A thief steals corporate secrets through dreams.",
+                        "tagline": "Your mind is the scene of the crime.",
+                        "genres": [{"id": 28, "name": "Action"}],
+                        "keywords": {
+                            "keywords": [
+                                {"id": 101, "name": "dream"},
+                                {"id": 102, "name": "subconscious"},
+                            ]
+                        },
+                    }
+                },
+            )
+            enricher = TMDBMovieEnricher(client, cache, run_id="test-run")
+
+            first = enricher.enrich_movie(
+                {"tconst": "tt1375666", "primary_title": "Inception", "startYear": "2010"}
+            )
+            second = enricher.enrich_movie(
+                {"tconst": "tt1375666", "primary_title": "Inception", "startYear": "2010"}
+            )
+
+            with sqlite3.connect(cache_path) as conn:
+                rows = conn.execute(
+                    "SELECT tconst, status, tmdb_id, overview, keywords_json, "
+                    "genres_json, source, source_api_version, source_language, run_id "
+                    "FROM tmdb_enrichment"
+                ).fetchall()
+
+        self.assertEqual(first.status, "fetched")
+        self.assertEqual(second.status, "skipped")
+        self.assertEqual(client.details_calls, [27205])
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][0:4], ("tt1375666", "fetched", 27205, first.overview))
+        self.assertEqual(json.loads(rows[0][4]), ["dream", "subconscious"])
+        self.assertEqual(json.loads(rows[0][5]), ["Action"])
+        self.assertEqual(rows[0][6:10], ("tmdb", "v3", "en-US", "test-run"))
+
+    def test_missing_and_ambiguous_results_are_recorded_without_details(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = TMDBEnrichmentCache(Path(tmp) / "tmdb.sqlite")
+            client = FakeTMDBClient(
+                {
+                    "tt0000001": [],
+                    "tt0000002": [
+                        {
+                            "id": 1,
+                            "title": "Wrong Movie",
+                            "original_title": "Wrong Movie",
+                            "release_date": "2001-01-01",
+                        }
+                    ],
+                }
+            )
+            enricher = TMDBMovieEnricher(client, cache)
+
+            missing = enricher.enrich_movie({"tconst": "tt0000001", "primary_title": "Sample Movie"})
+            ambiguous = enricher.enrich_movie(
+                {"tconst": "tt0000002", "primary_title": "Sample Sequel", "startYear": "2000"}
+            )
+
+            rows = cache.list_rows()
+
+        self.assertEqual(missing.status, "missing")
+        self.assertEqual(ambiguous.status, "ambiguous")
+        self.assertEqual(client.details_calls, [])
+        self.assertEqual(
+            [(row["tconst"], row["status"]) for row in rows],
+            [("tt0000001", "missing"), ("tt0000002", "ambiguous")],
+        )
+
+    def test_client_retries_429_with_retry_after(self) -> None:
+        retry_error = HTTPError(
+            url="https://api.themoviedb.org/3/find/tt1375666",
+            code=429,
+            msg="Too Many Requests",
+            hdrs={"Retry-After": "2"},
+            fp=None,
+        )
+        sleep = Mock()
+
+        with patch(
+            "movie_recommender.data.tmdb_enrichment.urlopen",
+            side_effect=[retry_error, FakeTMDBResponse({"movie_results": []})],
+        ):
+            client = TMDBClient("test-key", sleep=sleep, max_retries=1)
+            result = client.find_by_imdb_id("tt1375666")
+
+        self.assertEqual(result, [])
+        sleep.assert_called_once_with(2.0)
+
+    def test_client_error_does_not_include_api_key(self) -> None:
+        http_error = HTTPError(
+            url="https://api.themoviedb.org/3/find/tt1375666",
+            code=500,
+            msg="Server Error",
+            hdrs={},
+            fp=None,
+        )
+
+        with patch("movie_recommender.data.tmdb_enrichment.urlopen", side_effect=http_error):
+            client = TMDBClient("secret-api-key", max_retries=0)
+            with self.assertRaises(RuntimeError) as error:
+                client.find_by_imdb_id("tt1375666")
+
+        self.assertNotIn("secret-api-key", str(error.exception))
+
+    def test_error_status_is_retried_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = TMDBEnrichmentCache(Path(tmp) / "tmdb.sqlite")
+            client = FakeTMDBClient({"tt0000001": []})
+            enricher = TMDBMovieEnricher(client, cache)
+
+            cache.upsert(TMDBEnrichmentResult(tconst="tt0000001", status="error", error="temporary"))
+            result = enricher.enrich_movie({"tconst": "tt0000001", "primary_title": "Sample Movie"})
+
+        self.assertEqual(result.status, "missing")
+
+    def test_cli_dry_run_does_not_require_api_key(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        with tempfile.TemporaryDirectory() as tmp:
+            input_path = Path(tmp) / "movies.csv"
+            with input_path.open("w", encoding="utf-8", newline="") as handle:
+                writer = csv.DictWriter(handle, fieldnames=["tconst", "primary_title"])
+                writer.writeheader()
+                writer.writerow({"tconst": "tt1375666", "primary_title": "Inception"})
+
+            env = os.environ.copy()
+            env.pop("TMDB_API_KEY", None)
+            env["PYTHONPATH"] = str(repo_root / "src")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "movie_recommender.cli.tmdb_enrichment",
+                    "--input",
+                    str(input_path),
+                    "--cache",
+                    str(Path(tmp) / "tmdb.sqlite"),
+                    "--dry-run",
+                ],
+                cwd="/tmp",
+                env=env,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Would enrich 1 movie rows", result.stdout)
+
+    def test_cli_live_mode_requires_api_key(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        env = os.environ.copy()
+        env.pop("TMDB_API_KEY", None)
+        env["PYTHONPATH"] = str(repo_root / "src")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "movie_recommender.cli.tmdb_enrichment",
+                "--input",
+                str(repo_root / "fixtures" / "recommendation_eval_movies.csv"),
+            ],
+            cwd="/tmp",
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("TMDB_API_KEY is required", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tmdb_enrichment.py
+++ b/tmdb_enrichment.py
@@ -1,0 +1,15 @@
+#! python
+"""Thin wrapper for the TMDB enrichment CLI."""
+
+from pathlib import Path
+import sys
+
+SRC_DIR = Path(__file__).resolve().parent / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from movie_recommender.cli.tmdb_enrichment import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds an offline TMDB enrichment pipeline keyed by canonical IMDb `tconst`.
- Adds a resumable ignored SQLite cache/output with TMDB provenance, statuses, combined text, payload hashes, and retry/rate-limit handling.
- Adds a thin root CLI + Make target and README operator docs for dry-run/live usage.
- Keeps tests offline with mocked TMDB responses; no live TMDB calls or credentials required.

Closes #14

## Verification

```bash
.venv/bin/python -m pytest -q tests/data/test_tmdb_enrichment.py
# 7 passed in 0.47s

make test
# 50 passed in 7.56s

make smoke
# System check identified no issues (0 silenced).

.venv/bin/python tmdb_enrichment.py --help
# usage displayed for TMDB enrichment CLI

env -u TMDB_API_KEY .venv/bin/python tmdb_enrichment.py --input "$TMPDIR/movies.csv" --cache "$TMPDIR/tmdb.sqlite" --dry-run
# Would enrich 1 movie rows ...
# No TMDB requests made.

.venv/bin/python -m compileall -q src tests tmdb_enrichment.py
# compileall ok
```

## Notes
- I caught and fixed two issues during review before pushing: HTTP error messages no longer include the API key, and cached `error` rows retry by default instead of being treated as final.
- Live enrichment still fails closed without `TMDB_API_KEY`; dry-run works without credentials.

@codex review
