### PR TITLE
issue #16: add Postgres pgvector serving storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ DATASET_OUTPUT ?= movies_10
 DATASET_PERCENTAGE ?= 0.90
 DATASET_MIN_VOTES ?= 1000
 WEB_BIND ?= 127.0.0.1:8000
+DATABASE_URL ?= postgresql://movierec:movierec@127.0.0.1:54329/movierec
 
-.PHONY: setup test run-web smoke imdb-bootstrap canonical-dataset evaluate-recommendations clean
+.PHONY: setup test run-web smoke imdb-bootstrap canonical-dataset evaluate-recommendations db-up db-down db-schema db-load-tiny db-verify clean
 
 setup:
 	@if [ ! -x "$(VENV)/bin/python" ]; then \
@@ -48,6 +49,21 @@ canonical-dataset:
 
 evaluate-recommendations:
 	$(PYTHON) evaluate_recommendations.py $(ARGS)
+
+db-up:
+	docker compose up -d postgres
+
+db-down:
+	docker compose down
+
+db-schema:
+	DATABASE_URL="$(DATABASE_URL)" $(PYTHON) scripts/apply_serving_schema.py
+
+db-load-tiny:
+	DATABASE_URL="$(DATABASE_URL)" $(PYTHON) scripts/load_tiny_serving_fixture.py
+
+db-verify:
+	DATABASE_URL="$(DATABASE_URL)" $(PYTHON) scripts/verify_serving_queries.py
 
 clean:
 	find . -type d \( -name __pycache__ -o -name .pytest_cache \) -prune -exec rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -89,13 +89,17 @@ RECOMMENDER_CANDIDATE_LIMIT = 500
 If the SQLite store exists, the app can serve recommendations without the CSV
 being present. If neither exists, the app reports that the dataset is missing.
 
-Remaining steps toward the target architecture:
+Future serving direction, if development resumes:
 
-- move the SQLite schema into Postgres tables keyed by `tconst`,
-- replace term-overlap retrieval with pgvector ANN candidate retrieval,
-- keep the same two-stage shape: bounded retrieval first, richer rerank second,
-- expose the serving path through FastAPI after the bounded data path has been
-  validated in private preview.
+- keep the current SQLite path as the bounded local/private preview baseline,
+- use a managed Postgres provider such as Neon for pgvector serving storage rather
+  than hosting durable database state on the project/Juno VPS,
+- keep ETL and embedding generation as explicit offline jobs,
+- use a static frontend host such as Cloudflare Pages if the UI is split out,
+- choose a thin API layer only after the desired product flow is clear.
+
+Do not add infrastructure just because it is available. The current priority is
+figuring out what movie recommendation experience is actually worth building.
 
 ## Canonical Dataset Artifact
 
@@ -248,10 +252,13 @@ modes, such as a missing query title. The command exits with status 0 only when
 all seed cases pass, which makes it usable in local checks or CI without adding
 a full benchmark framework.
 
-### Future Work:
-- Make into a webapp using Django
-- Use database to provide backend data for webapp
-- Allow user to add more than one movie at a time
+## Future Work
+
+Development is paused while the product direction is reconsidered. If it resumes,
+prioritize a clear recommendation experience before adding more infrastructure.
+Likely next decisions are whether the app should remain a personal/private tool,
+what dataset size is useful, and whether the eventual UI/API split should use
+Cloudflare Pages plus a thin API over managed Postgres.
 
 Information courtesy of
 IMDb

--- a/db/README.md
+++ b/db/README.md
@@ -4,43 +4,43 @@ This directory contains the local development schema for the MovieRecommender
 serving store. It follows `docs/architecture/serving-schema-provenance.md` and
 keeps IMDb `tconst` as the canonical movie key.
 
-## Local setup
+## Target database
+
+The preferred target is a managed Postgres database with pgvector support, such
+as Neon. Keep durable database state out of the project/Juno VPS unless a real
+requirement beats the managed option.
+
+Set `DATABASE_URL` for the target database before running the schema or fixture
+commands:
+
+```bash
+export DATABASE_URL="postgresql://user:password@host/dbname?sslmode=require"
+make db-schema
+make db-load-tiny
+make db-verify
+```
+
+For Neon, use a development branch or throwaway database while validating schema
+changes. The schema uses standard Postgres plus `pg_trgm` and `vector`, so the
+same commands should work against any compatible Postgres provider.
+
+## Optional local Docker setup
+
+Docker Compose remains an optional convenience for machines where the current
+user is allowed to run Docker. It is not the required verification path.
 
 Start a local Postgres instance with pgvector and pg_trgm support:
 
 ```bash
 make db-up
-```
-
-The Docker Compose service uses local-only development credentials:
-
-```text
-postgresql://movierec:movierec@127.0.0.1:54329/movierec
-```
-
-Apply the schema:
-
-```bash
+export DATABASE_URL="postgresql://movierec:movierec@127.0.0.1:54329/movierec"
 make db-schema
-```
-
-Load the tiny fixture:
-
-```bash
 make db-load-tiny
-```
-
-Verify fuzzy title search, vector retrieval, and provenance:
-
-```bash
 make db-verify
 ```
 
-Use a different database by overriding `DATABASE_URL`:
-
-```bash
-make db-schema DATABASE_URL=postgresql://user:password@host:5432/dbname
-```
+The Compose service binds only to localhost and uses local-only development
+credentials.
 
 ## Schema notes
 

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,62 @@
+# Postgres Serving Store
+
+This directory contains the local development schema for the MovieRecommender
+serving store. It follows `docs/architecture/serving-schema-provenance.md` and
+keeps IMDb `tconst` as the canonical movie key.
+
+## Local setup
+
+Start a local Postgres instance with pgvector and pg_trgm support:
+
+```bash
+make db-up
+```
+
+The Docker Compose service uses local-only development credentials:
+
+```text
+postgresql://movierec:movierec@127.0.0.1:54329/movierec
+```
+
+Apply the schema:
+
+```bash
+make db-schema
+```
+
+Load the tiny fixture:
+
+```bash
+make db-load-tiny
+```
+
+Verify fuzzy title search, vector retrieval, and provenance:
+
+```bash
+make db-verify
+```
+
+Use a different database by overriding `DATABASE_URL`:
+
+```bash
+make db-schema DATABASE_URL=postgresql://user:password@host:5432/dbname
+```
+
+## Schema notes
+
+- `source_snapshots`, `etl_runs`, `etl_run_sources`, and `row_provenance`
+  capture load provenance.
+- `movies`, `movie_external_ids`, `people`, `person_external_ids`,
+  `movie_credits`, `movie_text_features`, and `movie_embeddings` are the serving
+  tables.
+- `pg_trgm` indexes support fuzzy title search over `display_title` and
+  `primary_title`.
+- `movie_embeddings.embedding` uses unbounded `vector` storage with a
+  `vector_dims(embedding) = vector_dimension` check so multiple dimensions can
+  coexist.
+- ANN indexes should be scoped to the configured feature/model/version/dimension
+  slice. The local verification script creates the tiny-fixture HNSW index.
+
+Embedding generation is intentionally out of scope here. App and API request
+paths should query existing rows only; text feature and embedding creation
+belong to offline ETL jobs.

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,219 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS source_snapshots (
+    source_snapshot_id BIGSERIAL PRIMARY KEY,
+    source_name TEXT NOT NULL,
+    snapshot_name TEXT NOT NULL,
+    snapshot_date DATE,
+    source_uri TEXT,
+    content_sha256 TEXT NOT NULL,
+    byte_size BIGINT,
+    row_count BIGINT,
+    schema_version TEXT,
+    fetched_at TIMESTAMPTZ,
+    notes TEXT,
+    UNIQUE NULLS NOT DISTINCT (
+        source_name,
+        snapshot_name,
+        snapshot_date,
+        content_sha256
+    )
+);
+
+CREATE TABLE IF NOT EXISTS etl_runs (
+    etl_run_id BIGSERIAL PRIMARY KEY,
+    run_type TEXT NOT NULL,
+    status TEXT NOT NULL,
+    started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    finished_at TIMESTAMPTZ,
+    code_version TEXT,
+    loader_name TEXT,
+    parameters JSONB NOT NULL DEFAULT '{}'::jsonb,
+    records_read BIGINT,
+    records_written BIGINT,
+    error_message TEXT
+);
+
+CREATE TABLE IF NOT EXISTS etl_run_sources (
+    etl_run_id BIGINT NOT NULL REFERENCES etl_runs(etl_run_id),
+    source_snapshot_id BIGINT NOT NULL REFERENCES source_snapshots(source_snapshot_id),
+    role TEXT NOT NULL,
+    PRIMARY KEY (etl_run_id, source_snapshot_id, role)
+);
+
+CREATE TABLE IF NOT EXISTS row_provenance (
+    row_provenance_id BIGSERIAL PRIMARY KEY,
+    table_name TEXT NOT NULL,
+    entity_key TEXT NOT NULL,
+    source_snapshot_id BIGINT NOT NULL REFERENCES source_snapshots(source_snapshot_id),
+    source_row_key TEXT,
+    source_row_hash TEXT,
+    etl_run_id BIGINT NOT NULL REFERENCES etl_runs(etl_run_id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS movies (
+    tconst TEXT PRIMARY KEY,
+    primary_title TEXT NOT NULL,
+    display_title TEXT NOT NULL,
+    original_title TEXT,
+    title_type TEXT,
+    start_year INTEGER,
+    end_year INTEGER,
+    runtime_minutes INTEGER,
+    genres TEXT[] NOT NULL DEFAULT '{}',
+    average_rating NUMERIC(3, 1),
+    num_votes INTEGER,
+    weighted_score DOUBLE PRECISION,
+    is_adult BOOLEAN,
+    active BOOLEAN NOT NULL DEFAULT true,
+    first_seen_etl_run_id BIGINT REFERENCES etl_runs(etl_run_id),
+    last_seen_etl_run_id BIGINT REFERENCES etl_runs(etl_run_id),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_movies_display_title_trgm
+    ON movies USING gin (display_title gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_movies_primary_title_trgm
+    ON movies USING gin (primary_title gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_movies_score
+    ON movies (weighted_score DESC NULLS LAST, display_title ASC, tconst ASC);
+
+CREATE TABLE IF NOT EXISTS movie_external_ids (
+    source_name TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    tconst TEXT NOT NULL REFERENCES movies(tconst),
+    source_snapshot_id BIGINT REFERENCES source_snapshots(source_snapshot_id),
+    etl_run_id BIGINT REFERENCES etl_runs(etl_run_id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (source_name, source_id),
+    UNIQUE (source_name, tconst)
+);
+
+CREATE TABLE IF NOT EXISTS people (
+    person_id BIGSERIAL PRIMARY KEY,
+    nconst TEXT UNIQUE,
+    primary_name TEXT NOT NULL,
+    birth_year INTEGER,
+    death_year INTEGER,
+    primary_professions TEXT[] NOT NULL DEFAULT '{}',
+    active BOOLEAN NOT NULL DEFAULT true,
+    first_seen_etl_run_id BIGINT REFERENCES etl_runs(etl_run_id),
+    last_seen_etl_run_id BIGINT REFERENCES etl_runs(etl_run_id),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS person_external_ids (
+    source_name TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    person_id BIGINT NOT NULL REFERENCES people(person_id),
+    source_snapshot_id BIGINT REFERENCES source_snapshots(source_snapshot_id),
+    etl_run_id BIGINT REFERENCES etl_runs(etl_run_id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (source_name, source_id),
+    UNIQUE (source_name, person_id)
+);
+
+CREATE TABLE IF NOT EXISTS movie_credits (
+    movie_credit_id BIGSERIAL PRIMARY KEY,
+    tconst TEXT NOT NULL REFERENCES movies(tconst),
+    person_id BIGINT NOT NULL REFERENCES people(person_id),
+    role_type TEXT NOT NULL,
+    category TEXT,
+    job TEXT,
+    character_names TEXT[] NOT NULL DEFAULT '{}',
+    credit_order INTEGER NOT NULL DEFAULT 0,
+    source_name TEXT NOT NULL,
+    source_snapshot_id BIGINT REFERENCES source_snapshots(source_snapshot_id),
+    etl_run_id BIGINT REFERENCES etl_runs(etl_run_id),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (tconst, person_id, role_type, credit_order)
+);
+
+CREATE INDEX IF NOT EXISTS idx_movie_credits_tconst_role
+    ON movie_credits (tconst, role_type, credit_order);
+
+CREATE INDEX IF NOT EXISTS idx_movie_credits_person
+    ON movie_credits (person_id, role_type);
+
+CREATE TABLE IF NOT EXISTS movie_text_features (
+    text_feature_id BIGSERIAL PRIMARY KEY,
+    tconst TEXT NOT NULL REFERENCES movies(tconst),
+    feature_name TEXT NOT NULL,
+    feature_version TEXT NOT NULL,
+    source_text TEXT NOT NULL,
+    source_text_sha256 TEXT NOT NULL,
+    build_method TEXT NOT NULL,
+    source_etl_run_id BIGINT NOT NULL REFERENCES etl_runs(etl_run_id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    active BOOLEAN NOT NULL DEFAULT true,
+    UNIQUE (
+        text_feature_id,
+        tconst,
+        feature_name,
+        feature_version,
+        source_text_sha256
+    ),
+    UNIQUE (tconst, feature_name, feature_version, source_text_sha256)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_movie_text_features_one_active
+    ON movie_text_features (tconst, feature_name, feature_version)
+    WHERE active;
+
+CREATE TABLE IF NOT EXISTS movie_embeddings (
+    movie_embedding_id BIGSERIAL PRIMARY KEY,
+    text_feature_id BIGINT NOT NULL REFERENCES movie_text_features(text_feature_id),
+    tconst TEXT NOT NULL REFERENCES movies(tconst),
+    feature_name TEXT NOT NULL,
+    feature_version TEXT NOT NULL,
+    model_name TEXT NOT NULL,
+    model_version TEXT NOT NULL,
+    vector_dimension INTEGER NOT NULL,
+    embedding vector NOT NULL,
+    embedding_sha256 TEXT,
+    source_text_sha256 TEXT NOT NULL,
+    embedding_etl_run_id BIGINT NOT NULL REFERENCES etl_runs(etl_run_id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    active BOOLEAN NOT NULL DEFAULT true,
+    CHECK (vector_dims(embedding) = vector_dimension),
+    FOREIGN KEY (
+        text_feature_id,
+        tconst,
+        feature_name,
+        feature_version,
+        source_text_sha256
+    )
+        REFERENCES movie_text_features(
+            text_feature_id,
+            tconst,
+            feature_name,
+            feature_version,
+            source_text_sha256
+        ),
+    UNIQUE (text_feature_id, model_name, model_version, vector_dimension)
+);
+
+CREATE INDEX IF NOT EXISTS idx_movie_embeddings_lookup
+    ON movie_embeddings (
+        tconst,
+        active,
+        feature_name,
+        feature_version,
+        model_name,
+        model_version,
+        vector_dimension
+    );
+
+CREATE INDEX IF NOT EXISTS idx_movie_embeddings_serving_slice
+    ON movie_embeddings (
+        active,
+        feature_name,
+        feature_version,
+        model_name,
+        model_version,
+        vector_dimension
+    );

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -130,7 +130,7 @@ CREATE TABLE IF NOT EXISTS movie_credits (
     source_snapshot_id BIGINT REFERENCES source_snapshots(source_snapshot_id),
     etl_run_id BIGINT REFERENCES etl_runs(etl_run_id),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    UNIQUE (tconst, person_id, role_type, credit_order)
+    UNIQUE (tconst, person_id, role_type, credit_order, source_name)
 );
 
 CREATE INDEX IF NOT EXISTS idx_movie_credits_tconst_role

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_USER: movierec
       POSTGRES_PASSWORD: movierec
     ports:
-      - "54329:5432"
+      - "127.0.0.1:54329:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U movierec -d movierec"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg17
+    environment:
+      POSTGRES_DB: movierec
+      POSTGRES_USER: movierec
+      POSTGRES_PASSWORD: movierec
+    ports:
+      - "54329:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U movierec -d movierec"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:

--- a/fixtures/storage/tiny_serving_fixture.json
+++ b/fixtures/storage/tiny_serving_fixture.json
@@ -1,0 +1,112 @@
+{
+  "embedding_config": {
+    "feature_name": "recommendation_soup",
+    "feature_version": "v1",
+    "model_name": "local-fixture-model",
+    "model_version": "2026-06-12",
+    "vector_dimension": 3
+  },
+  "source_snapshot": {
+    "source_name": "reduced_csv",
+    "snapshot_name": "tiny_serving_fixture.json",
+    "snapshot_date": null,
+    "source_uri": "fixtures/storage/tiny_serving_fixture.json",
+    "content_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "byte_size": 2,
+    "row_count": 2,
+    "schema_version": "tiny-v1",
+    "notes": "Local development fixture for the Postgres serving schema."
+  },
+  "etl_run": {
+    "run_type": "csv_backfill",
+    "status": "succeeded",
+    "loader_name": "tiny_fixture_loader",
+    "code_version": "local",
+    "records_read": 2,
+    "parameters": {
+      "fixture": "tiny_serving_fixture"
+    }
+  },
+  "people": [
+    {
+      "nconst": "nm0000001",
+      "primary_name": "Ada Director",
+      "primary_professions": ["director"]
+    },
+    {
+      "nconst": "nm0000002",
+      "primary_name": "Grace Actor",
+      "primary_professions": ["actor"]
+    }
+  ],
+  "movies": [
+    {
+      "tconst": "tt0000001",
+      "primary_title": "Arrival",
+      "display_title": "Arrival",
+      "original_title": "Arrival",
+      "title_type": "movie",
+      "start_year": 2016,
+      "runtime_minutes": 116,
+      "genres": ["Drama", "Sci-Fi"],
+      "average_rating": 7.9,
+      "num_votes": 750000,
+      "weighted_score": 8.7,
+      "is_adult": false,
+      "source_text": "arrival drama sci-fi ada director grace actor",
+      "embedding": [1.0, 0.0, 0.0],
+      "credits": [
+        {
+          "nconst": "nm0000001",
+          "role_type": "director",
+          "category": "director",
+          "job": null,
+          "character_names": [],
+          "credit_order": 0
+        },
+        {
+          "nconst": "nm0000002",
+          "role_type": "actor",
+          "category": "actor",
+          "job": null,
+          "character_names": ["Scientist"],
+          "credit_order": 1
+        }
+      ]
+    },
+    {
+      "tconst": "tt0000002",
+      "primary_title": "Arrival",
+      "display_title": "Arrival",
+      "original_title": "The Arrival",
+      "title_type": "movie",
+      "start_year": 1996,
+      "runtime_minutes": 115,
+      "genres": ["Mystery", "Sci-Fi"],
+      "average_rating": 6.2,
+      "num_votes": 40000,
+      "weighted_score": 6.9,
+      "is_adult": false,
+      "source_text": "arrival mystery sci-fi ada director grace actor",
+      "embedding": [0.9, 0.1, 0.0],
+      "credits": [
+        {
+          "nconst": "nm0000001",
+          "role_type": "director",
+          "category": "director",
+          "job": null,
+          "character_names": [],
+          "credit_order": 0
+        },
+        {
+          "nconst": "nm0000002",
+          "role_type": "actor",
+          "category": "actor",
+          "job": null,
+          "character_names": ["Radio Host"],
+          "credit_order": 1
+        }
+      ]
+    }
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ pandas>=2.1
 scikit-learn>=1.4
 scipy>=1.11
 Django>=5.2
+psycopg[binary]>=3.2
 pytest>=8.0

--- a/scripts/apply_serving_schema.py
+++ b/scripts/apply_serving_schema.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from movie_recommender.storage.postgres import SCHEMA_PATH, apply_schema  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Apply the Postgres serving schema.")
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get("DATABASE_URL"),
+        help="Postgres connection URL. Defaults to DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=SCHEMA_PATH,
+        help=f"Schema SQL path. Default: {SCHEMA_PATH}",
+    )
+    args = parser.parse_args()
+
+    if not args.database_url:
+        parser.error("--database-url or DATABASE_URL is required")
+
+    try:
+        import psycopg
+    except ImportError as exc:
+        raise SystemExit("psycopg is required; run `make setup` first") from exc
+
+    with psycopg.connect(args.database_url) as conn:
+        apply_schema(conn, args.schema)
+
+    print(f"Applied serving schema from {args.schema}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/load_tiny_serving_fixture.py
+++ b/scripts/load_tiny_serving_fixture.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from movie_recommender.storage.postgres import load_fixture_file  # noqa: E402
+
+
+DEFAULT_FIXTURE = REPO_ROOT / "fixtures" / "storage" / "tiny_serving_fixture.json"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Load the tiny Postgres serving fixture.")
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get("DATABASE_URL"),
+        help="Postgres connection URL. Defaults to DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        default=DEFAULT_FIXTURE,
+        help=f"Fixture JSON path. Default: {DEFAULT_FIXTURE}",
+    )
+    args = parser.parse_args()
+
+    if not args.database_url:
+        parser.error("--database-url or DATABASE_URL is required")
+
+    try:
+        import psycopg
+    except ImportError as exc:
+        raise SystemExit("psycopg is required; run `make setup` first") from exc
+
+    with psycopg.connect(args.database_url) as conn:
+        config = load_fixture_file(conn, args.fixture)
+
+    print(
+        "Loaded tiny serving fixture "
+        f"({config.feature_name}/{config.feature_version}, "
+        f"{config.model_name}/{config.model_version}, dim={config.vector_dimension})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_serving_queries.py
+++ b/scripts/verify_serving_queries.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from movie_recommender.storage.postgres import (  # noqa: E402
+    EmbeddingConfig,
+    build_ann_index_sql,
+    search_titles,
+    vector_recommendations,
+)
+
+
+DEFAULT_FIXTURE = REPO_ROOT / "fixtures" / "storage" / "tiny_serving_fixture.json"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify fuzzy title search, vector retrieval, and provenance."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get("DATABASE_URL"),
+        help="Postgres connection URL. Defaults to DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        default=DEFAULT_FIXTURE,
+        help=f"Fixture JSON path. Default: {DEFAULT_FIXTURE}",
+    )
+    args = parser.parse_args()
+
+    if not args.database_url:
+        parser.error("--database-url or DATABASE_URL is required")
+
+    try:
+        import psycopg
+    except ImportError as exc:
+        raise SystemExit("psycopg is required; run `make setup` first") from exc
+
+    fixture = json.loads(args.fixture.read_text(encoding="utf-8"))
+    config = EmbeddingConfig(**fixture["embedding_config"])
+
+    with psycopg.connect(args.database_url) as conn:
+        conn.execute(build_ann_index_sql(config))
+        conn.commit()
+
+        title_rows = search_titles(conn, "Arival", limit=5)
+        vector_rows = vector_recommendations(
+            conn,
+            "tt0000001",
+            config,
+            candidate_limit=5,
+        )
+        provenance_rows = _fetch_provenance(conn)
+
+    if {row["tconst"] for row in title_rows} != {"tt0000001", "tt0000002"}:
+        raise SystemExit(f"expected duplicate-title rows, got {title_rows!r}")
+    if not vector_rows or vector_rows[0]["tconst"] != "tt0000002":
+        raise SystemExit(f"expected tt0000002 nearest neighbor, got {vector_rows!r}")
+    if not provenance_rows:
+        raise SystemExit("expected row provenance for loaded movies")
+
+    print("Fuzzy title search:")
+    print(json.dumps(_jsonable(title_rows), indent=2, sort_keys=True))
+    print("Vector recommendations:")
+    print(json.dumps(_jsonable(vector_rows), indent=2, sort_keys=True))
+    print("Provenance trace:")
+    print(json.dumps(_jsonable(provenance_rows), indent=2, sort_keys=True))
+    return 0
+
+
+def _fetch_provenance(conn):
+    cur = conn.cursor()
+    cur.execute(
+        """
+SELECT rp.entity_key, er.run_type, ss.source_name, ss.snapshot_name
+FROM row_provenance rp
+JOIN etl_runs er ON er.etl_run_id = rp.etl_run_id
+JOIN source_snapshots ss ON ss.source_snapshot_id = rp.source_snapshot_id
+WHERE rp.table_name = 'movies'
+ORDER BY rp.entity_key;
+""".strip()
+    )
+    columns = [column.name for column in cur.description]
+    return [dict(zip(columns, row, strict=True)) for row in cur.fetchall()]
+
+
+def _jsonable(rows):
+    return [
+        {key: (float(value) if hasattr(value, "as_tuple") else value) for key, value in row.items()}
+        for row in rows
+    ]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/movie_recommender/storage/__init__.py
+++ b/src/movie_recommender/storage/__init__.py
@@ -1,0 +1,25 @@
+"""Storage helpers for the Postgres serving store."""
+
+from .postgres import (
+    EmbeddingConfig,
+    apply_schema,
+    build_ann_index_sql,
+    load_fixture,
+    render_fuzzy_title_search_sql,
+    render_vector_recommendations_sql,
+    search_titles,
+    validate_fixture_vectors,
+    vector_recommendations,
+)
+
+__all__ = [
+    "EmbeddingConfig",
+    "apply_schema",
+    "build_ann_index_sql",
+    "load_fixture",
+    "render_fuzzy_title_search_sql",
+    "render_vector_recommendations_sql",
+    "search_titles",
+    "validate_fixture_vectors",
+    "vector_recommendations",
+]

--- a/src/movie_recommender/storage/postgres.py
+++ b/src/movie_recommender/storage/postgres.py
@@ -1,0 +1,547 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = REPO_ROOT / "db" / "schema.sql"
+
+
+@dataclass(frozen=True)
+class EmbeddingConfig:
+    feature_name: str
+    feature_version: str
+    model_name: str
+    model_version: str
+    vector_dimension: int
+
+    def __post_init__(self) -> None:
+        if self.vector_dimension <= 0:
+            raise ValueError("vector_dimension must be positive")
+
+
+def apply_schema(conn: Any, schema_path: Path = SCHEMA_PATH) -> None:
+    conn.execute(schema_path.read_text(encoding="utf-8"))
+    conn.commit()
+
+
+def render_fuzzy_title_search_sql() -> str:
+    return """
+SELECT tconst, display_title, primary_title, start_year, weighted_score,
+       GREATEST(
+           similarity(display_title, %(query)s),
+           similarity(primary_title, %(query)s)
+       ) AS title_similarity
+FROM movies
+WHERE active
+  AND (
+      display_title % %(query)s
+      OR primary_title % %(query)s
+  )
+ORDER BY title_similarity DESC,
+         weighted_score DESC NULLS LAST,
+         display_title ASC,
+         tconst ASC
+LIMIT %(limit)s;
+""".strip()
+
+
+def render_vector_recommendations_sql(config: EmbeddingConfig) -> str:
+    dimension = _sql_dimension(config.vector_dimension)
+    feature_name = _sql_literal(config.feature_name)
+    feature_version = _sql_literal(config.feature_version)
+    model_name = _sql_literal(config.model_name)
+    model_version = _sql_literal(config.model_version)
+
+    return f"""
+WITH query_embedding AS (
+    SELECT e.embedding::vector({dimension}) AS embedding
+    FROM movie_embeddings e
+    JOIN movie_text_features tf
+      ON tf.text_feature_id = e.text_feature_id
+     AND tf.tconst = e.tconst
+     AND tf.feature_name = e.feature_name
+     AND tf.feature_version = e.feature_version
+     AND tf.source_text_sha256 = e.source_text_sha256
+    WHERE e.tconst = %(query_tconst)s
+      AND e.active
+      AND e.model_name = {model_name}
+      AND e.model_version = {model_version}
+      AND e.vector_dimension = {dimension}
+      AND e.feature_name = {feature_name}
+      AND e.feature_version = {feature_version}
+      AND tf.active
+)
+SELECT m.tconst,
+       m.display_title,
+       m.primary_title,
+       m.start_year,
+       m.weighted_score,
+       e.embedding::vector({dimension}) <=> q.embedding AS cosine_distance
+FROM query_embedding q
+JOIN movie_embeddings e
+  ON e.active
+ AND e.model_name = {model_name}
+ AND e.model_version = {model_version}
+ AND e.vector_dimension = {dimension}
+ AND e.feature_name = {feature_name}
+ AND e.feature_version = {feature_version}
+JOIN movie_text_features tf
+  ON tf.text_feature_id = e.text_feature_id
+ AND tf.tconst = e.tconst
+ AND tf.feature_name = e.feature_name
+ AND tf.feature_version = e.feature_version
+ AND tf.source_text_sha256 = e.source_text_sha256
+ AND tf.active
+JOIN movies m ON m.tconst = e.tconst
+WHERE e.tconst <> %(query_tconst)s
+  AND m.active
+ORDER BY e.embedding::vector({dimension}) <=> q.embedding,
+         m.weighted_score DESC NULLS LAST,
+         m.display_title ASC,
+         m.tconst ASC
+LIMIT %(candidate_limit)s;
+""".strip()
+
+
+def build_ann_index_sql(
+    config: EmbeddingConfig,
+    *,
+    index_name: str = "idx_movie_embeddings_ann_recommendation_soup_v1_local",
+) -> str:
+    _validate_identifier(index_name)
+    dimension = _sql_dimension(config.vector_dimension)
+    feature_name = _sql_literal(config.feature_name)
+    feature_version = _sql_literal(config.feature_version)
+    model_name = _sql_literal(config.model_name)
+    model_version = _sql_literal(config.model_version)
+
+    return f"""
+CREATE INDEX IF NOT EXISTS {index_name}
+    ON movie_embeddings
+    USING hnsw ((embedding::vector({dimension})) vector_cosine_ops)
+    WHERE active
+      AND feature_name = {feature_name}
+      AND feature_version = {feature_version}
+      AND model_name = {model_name}
+      AND model_version = {model_version}
+      AND vector_dimension = {dimension};
+""".strip()
+
+
+def search_titles(conn: Any, query: str, *, limit: int = 10) -> list[dict[str, Any]]:
+    cur = conn.cursor()
+    cur.execute(render_fuzzy_title_search_sql(), {"query": query, "limit": limit})
+    return _rows_to_dicts(cur)
+
+
+def vector_recommendations(
+    conn: Any,
+    query_tconst: str,
+    config: EmbeddingConfig,
+    *,
+    candidate_limit: int = 10,
+) -> list[dict[str, Any]]:
+    cur = conn.cursor()
+    cur.execute(
+        render_vector_recommendations_sql(config),
+        {"query_tconst": query_tconst, "candidate_limit": candidate_limit},
+    )
+    return _rows_to_dicts(cur)
+
+
+def validate_fixture_vectors(fixture: dict[str, Any], config: EmbeddingConfig) -> None:
+    if fixture.get("embedding_config") != {
+        "feature_name": config.feature_name,
+        "feature_version": config.feature_version,
+        "model_name": config.model_name,
+        "model_version": config.model_version,
+        "vector_dimension": config.vector_dimension,
+    }:
+        raise ValueError(
+            "fixture embedding_config does not match configured embedding space; "
+            "check feature/model values and vector_dimension"
+        )
+
+    for movie in fixture["movies"]:
+        vector = movie["embedding"]
+        if len(vector) != config.vector_dimension:
+            raise ValueError(
+                f"{movie['tconst']} vector_dimension mismatch: "
+                f"expected {config.vector_dimension}, got {len(vector)}"
+            )
+
+
+def load_fixture(conn: Any, fixture: dict[str, Any], config: EmbeddingConfig) -> None:
+    validate_fixture_vectors(fixture, config)
+    cur = conn.cursor()
+
+    source_snapshot_id = _upsert_source_snapshot(cur, fixture["source_snapshot"])
+    etl_run_id = _insert_etl_run(cur, fixture["etl_run"], len(fixture["movies"]))
+    _insert_etl_run_source(cur, etl_run_id, source_snapshot_id)
+
+    people_by_nconst: dict[str, int] = {}
+    for person in fixture.get("people", []):
+        people_by_nconst[person["nconst"]] = _upsert_person(cur, person)
+
+    for movie in fixture["movies"]:
+        _upsert_movie(cur, movie, etl_run_id)
+        _upsert_movie_external_id(cur, movie["tconst"], source_snapshot_id, etl_run_id)
+        _insert_movie_provenance(cur, movie, source_snapshot_id, etl_run_id)
+
+        for credit in movie.get("credits", []):
+            person_id = people_by_nconst[credit["nconst"]]
+            _upsert_credit(cur, movie["tconst"], person_id, credit, source_snapshot_id, etl_run_id)
+
+        text_feature_id = _upsert_text_feature(cur, movie, config, etl_run_id)
+        _upsert_embedding(cur, movie, text_feature_id, config, etl_run_id)
+
+    conn.commit()
+
+
+def load_fixture_file(conn: Any, fixture_path: Path) -> EmbeddingConfig:
+    fixture_bytes = fixture_path.read_bytes()
+    fixture = json.loads(fixture_bytes.decode("utf-8"))
+    fixture["source_snapshot"]["content_sha256"] = hashlib.sha256(fixture_bytes).hexdigest()
+    fixture["source_snapshot"]["byte_size"] = len(fixture_bytes)
+    fixture["source_snapshot"]["row_count"] = len(fixture["movies"])
+    config = EmbeddingConfig(**fixture["embedding_config"])
+    load_fixture(conn, fixture, config)
+    return config
+
+
+def _upsert_source_snapshot(cur: Any, snapshot: dict[str, Any]) -> int:
+    cur.execute(
+        """
+INSERT INTO source_snapshots (
+    source_name, snapshot_name, snapshot_date, source_uri, content_sha256,
+    byte_size, row_count, schema_version, notes
+)
+VALUES (
+    %(source_name)s, %(snapshot_name)s, %(snapshot_date)s, %(source_uri)s,
+    %(content_sha256)s, %(byte_size)s, %(row_count)s, %(schema_version)s, %(notes)s
+)
+ON CONFLICT (source_name, snapshot_name, snapshot_date, content_sha256)
+DO UPDATE SET
+    source_uri = EXCLUDED.source_uri,
+    byte_size = EXCLUDED.byte_size,
+    row_count = EXCLUDED.row_count,
+    schema_version = EXCLUDED.schema_version,
+    notes = EXCLUDED.notes
+RETURNING source_snapshot_id;
+""".strip(),
+        snapshot,
+    )
+    return cur.fetchone()[0]
+
+
+def _insert_etl_run(cur: Any, etl_run: dict[str, Any], records_written: int) -> int:
+    cur.execute(
+        """
+INSERT INTO etl_runs (
+    run_type, status, finished_at, code_version, loader_name, parameters,
+    records_read, records_written
+)
+VALUES (
+    %(run_type)s, %(status)s, now(), %(code_version)s, %(loader_name)s,
+    %(parameters)s::jsonb, %(records_read)s, %(records_written)s
+)
+RETURNING etl_run_id;
+""".strip(),
+        {
+            "run_type": etl_run["run_type"],
+            "status": etl_run["status"],
+            "code_version": etl_run.get("code_version"),
+            "loader_name": etl_run["loader_name"],
+            "parameters": json.dumps(etl_run.get("parameters", {})),
+            "records_read": etl_run.get("records_read", records_written),
+            "records_written": records_written,
+        },
+    )
+    return cur.fetchone()[0]
+
+
+def _insert_etl_run_source(cur: Any, etl_run_id: int, source_snapshot_id: int) -> None:
+    cur.execute(
+        """
+INSERT INTO etl_run_sources (etl_run_id, source_snapshot_id, role)
+VALUES (%(etl_run_id)s, %(source_snapshot_id)s, 'tiny_fixture')
+ON CONFLICT DO NOTHING;
+""".strip(),
+        {"etl_run_id": etl_run_id, "source_snapshot_id": source_snapshot_id},
+    )
+
+
+def _upsert_person(cur: Any, person: dict[str, Any]) -> int:
+    cur.execute(
+        """
+INSERT INTO people (nconst, primary_name, primary_professions, active)
+VALUES (%(nconst)s, %(primary_name)s, %(primary_professions)s, true)
+ON CONFLICT (nconst) DO UPDATE SET
+    primary_name = EXCLUDED.primary_name,
+    primary_professions = EXCLUDED.primary_professions,
+    active = true,
+    updated_at = now()
+RETURNING person_id;
+""".strip(),
+        person,
+    )
+    return cur.fetchone()[0]
+
+
+def _upsert_movie(cur: Any, movie: dict[str, Any], etl_run_id: int) -> None:
+    cur.execute(
+        """
+INSERT INTO movies (
+    tconst, primary_title, display_title, original_title, title_type, start_year,
+    runtime_minutes, genres, average_rating, num_votes, weighted_score,
+    is_adult, active, first_seen_etl_run_id, last_seen_etl_run_id
+)
+VALUES (
+    %(tconst)s, %(primary_title)s, %(display_title)s, %(original_title)s,
+    %(title_type)s, %(start_year)s, %(runtime_minutes)s, %(genres)s,
+    %(average_rating)s, %(num_votes)s, %(weighted_score)s, %(is_adult)s,
+    true, %(etl_run_id)s, %(etl_run_id)s
+)
+ON CONFLICT (tconst) DO UPDATE SET
+    primary_title = EXCLUDED.primary_title,
+    display_title = EXCLUDED.display_title,
+    original_title = EXCLUDED.original_title,
+    title_type = EXCLUDED.title_type,
+    start_year = EXCLUDED.start_year,
+    runtime_minutes = EXCLUDED.runtime_minutes,
+    genres = EXCLUDED.genres,
+    average_rating = EXCLUDED.average_rating,
+    num_votes = EXCLUDED.num_votes,
+    weighted_score = EXCLUDED.weighted_score,
+    is_adult = EXCLUDED.is_adult,
+    active = true,
+    last_seen_etl_run_id = EXCLUDED.last_seen_etl_run_id,
+    updated_at = now();
+""".strip(),
+        {**movie, "etl_run_id": etl_run_id},
+    )
+
+
+def _upsert_movie_external_id(
+    cur: Any,
+    tconst: str,
+    source_snapshot_id: int,
+    etl_run_id: int,
+) -> None:
+    cur.execute(
+        """
+INSERT INTO movie_external_ids (
+    source_name, source_id, tconst, source_snapshot_id, etl_run_id
+)
+VALUES ('imdb', %(tconst)s, %(tconst)s, %(source_snapshot_id)s, %(etl_run_id)s)
+ON CONFLICT (source_name, source_id) DO UPDATE SET
+    tconst = EXCLUDED.tconst,
+    source_snapshot_id = EXCLUDED.source_snapshot_id,
+    etl_run_id = EXCLUDED.etl_run_id;
+""".strip(),
+        {
+            "tconst": tconst,
+            "source_snapshot_id": source_snapshot_id,
+            "etl_run_id": etl_run_id,
+        },
+    )
+
+
+def _insert_movie_provenance(
+    cur: Any,
+    movie: dict[str, Any],
+    source_snapshot_id: int,
+    etl_run_id: int,
+) -> None:
+    source_row_hash = hashlib.sha256(
+        json.dumps(movie, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    cur.execute(
+        """
+INSERT INTO row_provenance (
+    table_name, entity_key, source_snapshot_id, source_row_key,
+    source_row_hash, etl_run_id
+)
+VALUES (
+    'movies', %(tconst)s, %(source_snapshot_id)s, %(tconst)s,
+    %(source_row_hash)s, %(etl_run_id)s
+);
+""".strip(),
+        {
+            "tconst": movie["tconst"],
+            "source_snapshot_id": source_snapshot_id,
+            "source_row_hash": source_row_hash,
+            "etl_run_id": etl_run_id,
+        },
+    )
+
+
+def _upsert_credit(
+    cur: Any,
+    tconst: str,
+    person_id: int,
+    credit: dict[str, Any],
+    source_snapshot_id: int,
+    etl_run_id: int,
+) -> None:
+    cur.execute(
+        """
+INSERT INTO movie_credits (
+    tconst, person_id, role_type, category, job, character_names,
+    credit_order, source_name, source_snapshot_id, etl_run_id
+)
+VALUES (
+    %(tconst)s, %(person_id)s, %(role_type)s, %(category)s, %(job)s,
+    %(character_names)s, %(credit_order)s, 'tiny_fixture',
+    %(source_snapshot_id)s, %(etl_run_id)s
+)
+ON CONFLICT (tconst, person_id, role_type, credit_order) DO UPDATE SET
+    category = EXCLUDED.category,
+    job = EXCLUDED.job,
+    character_names = EXCLUDED.character_names,
+    source_name = EXCLUDED.source_name,
+    source_snapshot_id = EXCLUDED.source_snapshot_id,
+    etl_run_id = EXCLUDED.etl_run_id,
+    updated_at = now();
+""".strip(),
+        {
+            **credit,
+            "tconst": tconst,
+            "person_id": person_id,
+            "source_snapshot_id": source_snapshot_id,
+            "etl_run_id": etl_run_id,
+        },
+    )
+
+
+def _upsert_text_feature(
+    cur: Any,
+    movie: dict[str, Any],
+    config: EmbeddingConfig,
+    etl_run_id: int,
+) -> int:
+    source_text = movie["source_text"]
+    source_text_sha256 = hashlib.sha256(source_text.encode("utf-8")).hexdigest()
+    cur.execute(
+        """
+UPDATE movie_text_features
+SET active = false
+WHERE tconst = %(tconst)s
+  AND feature_name = %(feature_name)s
+  AND feature_version = %(feature_version)s
+  AND source_text_sha256 <> %(source_text_sha256)s
+  AND active;
+""".strip(),
+        {
+            "tconst": movie["tconst"],
+            "feature_name": config.feature_name,
+            "feature_version": config.feature_version,
+            "source_text_sha256": source_text_sha256,
+        },
+    )
+    cur.execute(
+        """
+INSERT INTO movie_text_features (
+    tconst, feature_name, feature_version, source_text, source_text_sha256,
+    build_method, source_etl_run_id, active
+)
+VALUES (
+    %(tconst)s, %(feature_name)s, %(feature_version)s, %(source_text)s,
+    %(source_text_sha256)s, 'tiny_fixture', %(etl_run_id)s, true
+)
+ON CONFLICT (tconst, feature_name, feature_version, source_text_sha256)
+DO UPDATE SET
+    source_text = EXCLUDED.source_text,
+    build_method = EXCLUDED.build_method,
+    source_etl_run_id = EXCLUDED.source_etl_run_id,
+    active = true
+RETURNING text_feature_id;
+""".strip(),
+        {
+            "tconst": movie["tconst"],
+            "feature_name": config.feature_name,
+            "feature_version": config.feature_version,
+            "source_text": source_text,
+            "source_text_sha256": source_text_sha256,
+            "etl_run_id": etl_run_id,
+        },
+    )
+    return cur.fetchone()[0]
+
+
+def _upsert_embedding(
+    cur: Any,
+    movie: dict[str, Any],
+    text_feature_id: int,
+    config: EmbeddingConfig,
+    etl_run_id: int,
+) -> None:
+    embedding = _format_vector(movie["embedding"])
+    source_text_sha256 = hashlib.sha256(movie["source_text"].encode("utf-8")).hexdigest()
+    embedding_sha256 = hashlib.sha256(embedding.encode("utf-8")).hexdigest()
+    cur.execute(
+        """
+INSERT INTO movie_embeddings (
+    text_feature_id, tconst, feature_name, feature_version, model_name,
+    model_version, vector_dimension, embedding, embedding_sha256,
+    source_text_sha256, embedding_etl_run_id, active
+)
+VALUES (
+    %(text_feature_id)s, %(tconst)s, %(feature_name)s, %(feature_version)s,
+    %(model_name)s, %(model_version)s, %(vector_dimension)s,
+    %(embedding)s::vector, %(embedding_sha256)s, %(source_text_sha256)s,
+    %(etl_run_id)s, true
+)
+ON CONFLICT (text_feature_id, model_name, model_version, vector_dimension)
+DO UPDATE SET
+    embedding = EXCLUDED.embedding,
+    embedding_sha256 = EXCLUDED.embedding_sha256,
+    source_text_sha256 = EXCLUDED.source_text_sha256,
+    embedding_etl_run_id = EXCLUDED.embedding_etl_run_id,
+    active = true;
+""".strip(),
+        {
+            "text_feature_id": text_feature_id,
+            "tconst": movie["tconst"],
+            "feature_name": config.feature_name,
+            "feature_version": config.feature_version,
+            "model_name": config.model_name,
+            "model_version": config.model_version,
+            "vector_dimension": config.vector_dimension,
+            "embedding": embedding,
+            "embedding_sha256": embedding_sha256,
+            "source_text_sha256": source_text_sha256,
+            "etl_run_id": etl_run_id,
+        },
+    )
+
+
+def _rows_to_dicts(cur: Any) -> list[dict[str, Any]]:
+    columns = [column.name for column in cur.description]
+    return [dict(zip(columns, row, strict=True)) for row in cur.fetchall()]
+
+
+def _format_vector(values: list[float]) -> str:
+    return "[" + ",".join(str(value) for value in values) + "]"
+
+
+def _sql_dimension(value: int) -> int:
+    if value <= 0:
+        raise ValueError("vector_dimension must be positive")
+    return value
+
+
+def _sql_literal(value: str) -> str:
+    if "\x00" in value:
+        raise ValueError("SQL literals cannot contain NUL bytes")
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _validate_identifier(value: str) -> None:
+    if not value.replace("_", "").isalnum() or value[0].isdigit():
+        raise ValueError(f"invalid SQL identifier: {value!r}")

--- a/src/movie_recommender/storage/postgres.py
+++ b/src/movie_recommender/storage/postgres.py
@@ -9,6 +9,8 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCHEMA_PATH = REPO_ROOT / "db" / "schema.sql"
+POSTGRES_IDENTIFIER_MAX_BYTES = 63
+PGVECTOR_HNSW_VECTOR_MAX_DIMENSIONS = 2000
 
 
 @dataclass(frozen=True)
@@ -67,6 +69,8 @@ WITH query_embedding AS (
      AND tf.feature_name = e.feature_name
      AND tf.feature_version = e.feature_version
      AND tf.source_text_sha256 = e.source_text_sha256
+    JOIN movies qm ON qm.tconst = e.tconst
+     AND qm.active
     WHERE e.tconst = %(query_tconst)s
       AND e.active
       AND e.model_name = {model_name}
@@ -117,6 +121,11 @@ def build_ann_index_sql(
         index_name = _default_ann_index_name(config)
     _validate_identifier(index_name)
     dimension = _sql_dimension(config.vector_dimension)
+    if dimension > PGVECTOR_HNSW_VECTOR_MAX_DIMENSIONS:
+        raise ValueError(
+            "HNSW vector indexes support at most "
+            f"{PGVECTOR_HNSW_VECTOR_MAX_DIMENSIONS} dimensions for vector columns"
+        )
     feature_name = _sql_literal(config.feature_name)
     feature_version = _sql_literal(config.feature_version)
     model_name = _sql_literal(config.model_name)
@@ -300,12 +309,12 @@ def _upsert_movie(cur: Any, movie: dict[str, Any], etl_run_id: int) -> None:
         """
 INSERT INTO movies (
     tconst, primary_title, display_title, original_title, title_type, start_year,
-    runtime_minutes, genres, average_rating, num_votes, weighted_score,
+    end_year, runtime_minutes, genres, average_rating, num_votes, weighted_score,
     is_adult, active, first_seen_etl_run_id, last_seen_etl_run_id
 )
 VALUES (
     %(tconst)s, %(primary_title)s, %(display_title)s, %(original_title)s,
-    %(title_type)s, %(start_year)s, %(runtime_minutes)s, %(genres)s,
+    %(title_type)s, %(start_year)s, %(end_year)s, %(runtime_minutes)s, %(genres)s,
     %(average_rating)s, %(num_votes)s, %(weighted_score)s, %(is_adult)s,
     true, %(etl_run_id)s, %(etl_run_id)s
 )
@@ -315,6 +324,7 @@ ON CONFLICT (tconst) DO UPDATE SET
     original_title = EXCLUDED.original_title,
     title_type = EXCLUDED.title_type,
     start_year = EXCLUDED.start_year,
+    end_year = EXCLUDED.end_year,
     runtime_minutes = EXCLUDED.runtime_minutes,
     genres = EXCLUDED.genres,
     average_rating = EXCLUDED.average_rating,
@@ -325,7 +335,7 @@ ON CONFLICT (tconst) DO UPDATE SET
     last_seen_etl_run_id = EXCLUDED.last_seen_etl_run_id,
     updated_at = now();
 """.strip(),
-        {**movie, "etl_run_id": etl_run_id},
+        {**movie, "end_year": movie.get("end_year"), "etl_run_id": etl_run_id},
     )
 
 
@@ -573,10 +583,11 @@ def _default_ann_index_name(config: EmbeddingConfig) -> str:
         str(config.vector_dimension),
     ]
     digest = hashlib.sha256("|".join(name_parts).encode("utf-8")).hexdigest()[:12]
-    feature = _identifier_fragment(config.feature_name, max_length=18)
-    version = _identifier_fragment(config.feature_version, max_length=10)
-    dimension = _identifier_fragment(str(config.vector_dimension), max_length=6)
-    return f"idx_movie_emb_ann_{feature}_{version}_{dimension}_{digest}"
+    feature = _identifier_fragment(config.feature_name, max_length=16)
+    version = _identifier_fragment(config.feature_version, max_length=8)
+    dimension = _identifier_fragment(str(config.vector_dimension), max_length=5)
+    name = f"idx_movie_emb_ann_{feature}_{version}_{dimension}_{digest}"
+    return name[:POSTGRES_IDENTIFIER_MAX_BYTES].rstrip("_")
 
 
 def _identifier_fragment(value: str, *, max_length: int) -> str:

--- a/src/movie_recommender/storage/postgres.py
+++ b/src/movie_recommender/storage/postgres.py
@@ -39,8 +39,8 @@ SELECT tconst, display_title, primary_title, start_year, weighted_score,
 FROM movies
 WHERE active
   AND (
-      display_title % %(query)s
-      OR primary_title % %(query)s
+      display_title %% %(query)s
+      OR primary_title %% %(query)s
   )
 ORDER BY title_similarity DESC,
          weighted_score DESC NULLS LAST,
@@ -111,8 +111,10 @@ LIMIT %(candidate_limit)s;
 def build_ann_index_sql(
     config: EmbeddingConfig,
     *,
-    index_name: str = "idx_movie_embeddings_ann_recommendation_soup_v1_local",
+    index_name: str | None = None,
 ) -> str:
+    if index_name is None:
+        index_name = _default_ann_index_name(config)
     _validate_identifier(index_name)
     dimension = _sql_dimension(config.vector_dimension)
     feature_name = _sql_literal(config.feature_name)
@@ -429,6 +431,26 @@ def _upsert_text_feature(
     source_text_sha256 = hashlib.sha256(source_text.encode("utf-8")).hexdigest()
     cur.execute(
         """
+UPDATE movie_embeddings
+SET active = false
+FROM movie_text_features
+WHERE movie_embeddings.text_feature_id = movie_text_features.text_feature_id
+  AND movie_text_features.tconst = %(tconst)s
+  AND movie_text_features.feature_name = %(feature_name)s
+  AND movie_text_features.feature_version = %(feature_version)s
+  AND movie_text_features.source_text_sha256 <> %(source_text_sha256)s
+  AND movie_text_features.active
+  AND movie_embeddings.active;
+""".strip(),
+        {
+            "tconst": movie["tconst"],
+            "feature_name": config.feature_name,
+            "feature_version": config.feature_version,
+            "source_text_sha256": source_text_sha256,
+        },
+    )
+    cur.execute(
+        """
 UPDATE movie_text_features
 SET active = false
 WHERE tconst = %(tconst)s
@@ -540,6 +562,29 @@ def _sql_literal(value: str) -> str:
     if "\x00" in value:
         raise ValueError("SQL literals cannot contain NUL bytes")
     return "'" + value.replace("'", "''") + "'"
+
+
+def _default_ann_index_name(config: EmbeddingConfig) -> str:
+    name_parts = [
+        config.feature_name,
+        config.feature_version,
+        config.model_name,
+        config.model_version,
+        str(config.vector_dimension),
+    ]
+    digest = hashlib.sha256("|".join(name_parts).encode("utf-8")).hexdigest()[:12]
+    feature = _identifier_fragment(config.feature_name, max_length=18)
+    version = _identifier_fragment(config.feature_version, max_length=10)
+    dimension = _identifier_fragment(str(config.vector_dimension), max_length=6)
+    return f"idx_movie_emb_ann_{feature}_{version}_{dimension}_{digest}"
+
+
+def _identifier_fragment(value: str, *, max_length: int) -> str:
+    chars = [char.lower() if char.isalnum() else "_" for char in value]
+    fragment = "".join(chars).strip("_")
+    while "__" in fragment:
+        fragment = fragment.replace("__", "_")
+    return (fragment or "x")[:max_length].strip("_") or "x"
 
 
 def _validate_identifier(value: str) -> None:

--- a/src/movie_recommender/storage/postgres.py
+++ b/src/movie_recommender/storage/postgres.py
@@ -198,7 +198,6 @@ def load_fixture(conn: Any, fixture: dict[str, Any], config: EmbeddingConfig) ->
         cur,
         active_tconsts=[movie["tconst"] for movie in fixture["movies"]],
         loader_name=fixture["etl_run"]["loader_name"],
-        etl_run_id=etl_run_id,
     )
 
     people_by_nconst: dict[str, int] = {}
@@ -299,12 +298,10 @@ def _deactivate_missing_fixture_movies(
     *,
     active_tconsts: list[str],
     loader_name: str,
-    etl_run_id: int,
 ) -> None:
     params = {
         "active_tconsts": active_tconsts,
         "loader_name": loader_name,
-        "etl_run_id": etl_run_id,
     }
     cur.execute(
         """
@@ -337,7 +334,6 @@ WHERE movie_text_features.tconst = movies.tconst
         """
 UPDATE movies
 SET active = false,
-    last_seen_etl_run_id = %(etl_run_id)s,
     updated_at = now()
 FROM etl_runs
 WHERE movies.last_seen_etl_run_id = etl_runs.etl_run_id
@@ -485,7 +481,7 @@ VALUES (
     %(character_names)s, %(credit_order)s, 'tiny_fixture',
     %(source_snapshot_id)s, %(etl_run_id)s
 )
-ON CONFLICT (tconst, person_id, role_type, credit_order) DO UPDATE SET
+ON CONFLICT (tconst, person_id, role_type, credit_order, source_name) DO UPDATE SET
     category = EXCLUDED.category,
     job = EXCLUDED.job,
     character_names = EXCLUDED.character_names,

--- a/src/movie_recommender/storage/postgres.py
+++ b/src/movie_recommender/storage/postgres.py
@@ -489,10 +489,10 @@ ON CONFLICT (tconst, person_id, role_type, credit_order) DO UPDATE SET
     category = EXCLUDED.category,
     job = EXCLUDED.job,
     character_names = EXCLUDED.character_names,
-    source_name = EXCLUDED.source_name,
     source_snapshot_id = EXCLUDED.source_snapshot_id,
     etl_run_id = EXCLUDED.etl_run_id,
-    updated_at = now();
+    updated_at = now()
+WHERE movie_credits.source_name = 'tiny_fixture';
 """.strip(),
         {
             **credit,
@@ -675,5 +675,10 @@ def _identifier_fragment(value: str, *, max_length: int) -> str:
 
 
 def _validate_identifier(value: str) -> None:
+    if len(value.encode("utf-8")) > POSTGRES_IDENTIFIER_MAX_BYTES:
+        raise ValueError(
+            "SQL identifiers must be no more than "
+            f"{POSTGRES_IDENTIFIER_MAX_BYTES} UTF-8 bytes"
+        )
     if not value.replace("_", "").isalnum() or value[0].isdigit():
         raise ValueError(f"invalid SQL identifier: {value!r}")

--- a/src/movie_recommender/storage/postgres.py
+++ b/src/movie_recommender/storage/postgres.py
@@ -194,6 +194,12 @@ def load_fixture(conn: Any, fixture: dict[str, Any], config: EmbeddingConfig) ->
     source_snapshot_id = _upsert_source_snapshot(cur, fixture["source_snapshot"])
     etl_run_id = _insert_etl_run(cur, fixture["etl_run"], len(fixture["movies"]))
     _insert_etl_run_source(cur, etl_run_id, source_snapshot_id)
+    _deactivate_missing_fixture_movies(
+        cur,
+        active_tconsts=[movie["tconst"] for movie in fixture["movies"]],
+        loader_name=fixture["etl_run"]["loader_name"],
+        etl_run_id=etl_run_id,
+    )
 
     people_by_nconst: dict[str, int] = {}
     for person in fixture.get("people", []):
@@ -204,6 +210,7 @@ def load_fixture(conn: Any, fixture: dict[str, Any], config: EmbeddingConfig) ->
         _upsert_movie_external_id(cur, movie["tconst"], source_snapshot_id, etl_run_id)
         _insert_movie_provenance(cur, movie, source_snapshot_id, etl_run_id)
 
+        _delete_existing_fixture_credits(cur, movie["tconst"])
         for credit in movie.get("credits", []):
             person_id = people_by_nconst[credit["nconst"]]
             _upsert_credit(cur, movie["tconst"], person_id, credit, source_snapshot_id, etl_run_id)
@@ -284,6 +291,61 @@ VALUES (%(etl_run_id)s, %(source_snapshot_id)s, 'tiny_fixture')
 ON CONFLICT DO NOTHING;
 """.strip(),
         {"etl_run_id": etl_run_id, "source_snapshot_id": source_snapshot_id},
+    )
+
+
+def _deactivate_missing_fixture_movies(
+    cur: Any,
+    *,
+    active_tconsts: list[str],
+    loader_name: str,
+    etl_run_id: int,
+) -> None:
+    params = {
+        "active_tconsts": active_tconsts,
+        "loader_name": loader_name,
+        "etl_run_id": etl_run_id,
+    }
+    cur.execute(
+        """
+UPDATE movie_embeddings
+SET active = false
+FROM movie_text_features, movies, etl_runs
+WHERE movie_embeddings.text_feature_id = movie_text_features.text_feature_id
+  AND movie_text_features.tconst = movies.tconst
+  AND movies.last_seen_etl_run_id = etl_runs.etl_run_id
+  AND etl_runs.loader_name = %(loader_name)s
+  AND movies.tconst <> ALL(%(active_tconsts)s::text[])
+  AND movie_embeddings.active;
+""".strip(),
+        params,
+    )
+    cur.execute(
+        """
+UPDATE movie_text_features
+SET active = false
+FROM movies, etl_runs
+WHERE movie_text_features.tconst = movies.tconst
+  AND movies.last_seen_etl_run_id = etl_runs.etl_run_id
+  AND etl_runs.loader_name = %(loader_name)s
+  AND movies.tconst <> ALL(%(active_tconsts)s::text[])
+  AND movie_text_features.active;
+""".strip(),
+        params,
+    )
+    cur.execute(
+        """
+UPDATE movies
+SET active = false,
+    last_seen_etl_run_id = %(etl_run_id)s,
+    updated_at = now()
+FROM etl_runs
+WHERE movies.last_seen_etl_run_id = etl_runs.etl_run_id
+  AND etl_runs.loader_name = %(loader_name)s
+  AND movies.tconst <> ALL(%(active_tconsts)s::text[])
+  AND movies.active;
+""".strip(),
+        params,
     )
 
 
@@ -390,6 +452,17 @@ VALUES (
             "source_row_hash": source_row_hash,
             "etl_run_id": etl_run_id,
         },
+    )
+
+
+def _delete_existing_fixture_credits(cur: Any, tconst: str) -> None:
+    cur.execute(
+        """
+DELETE FROM movie_credits
+WHERE tconst = %(tconst)s
+  AND source_name = 'tiny_fixture';
+""".strip(),
+        {"tconst": tconst},
     )
 
 
@@ -591,7 +664,10 @@ def _default_ann_index_name(config: EmbeddingConfig) -> str:
 
 
 def _identifier_fragment(value: str, *, max_length: int) -> str:
-    chars = [char.lower() if char.isalnum() else "_" for char in value]
+    chars = [
+        char.lower() if char.isascii() and char.isalnum() else "_"
+        for char in value
+    ]
     fragment = "".join(chars).strip("_")
     while "__" in fragment:
         fragment = fragment.replace("__", "_")

--- a/tests/storage/test_postgres_integration.py
+++ b/tests/storage/test_postgres_integration.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from movie_recommender.storage.postgres import (
+    EmbeddingConfig,
+    apply_schema,
+    build_ann_index_sql,
+    load_fixture,
+    search_titles,
+    vector_recommendations,
+)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("POSTGRES_TEST_DSN"),
+    reason="set POSTGRES_TEST_DSN to run Postgres/pgvector integration tests",
+)
+def test_tiny_fixture_search_vector_and_provenance_round_trip() -> None:
+    psycopg = pytest.importorskip("psycopg")
+    fixture = json.loads(
+        Path("fixtures/storage/tiny_serving_fixture.json").read_text(encoding="utf-8")
+    )
+    config = EmbeddingConfig(**fixture["embedding_config"])
+
+    with psycopg.connect(os.environ["POSTGRES_TEST_DSN"]) as conn:
+        apply_schema(conn)
+        load_fixture(conn, fixture, config)
+        conn.execute(build_ann_index_sql(config))
+        conn.commit()
+
+        title_rows = search_titles(conn, "Arival", limit=5)
+        vector_rows = vector_recommendations(
+            conn,
+            "tt0000001",
+            config,
+            candidate_limit=5,
+        )
+        provenance_count = conn.execute(
+            "SELECT count(*) FROM row_provenance WHERE table_name = 'movies';"
+        ).fetchone()[0]
+
+    assert {row["tconst"] for row in title_rows} == {"tt0000001", "tt0000002"}
+    assert vector_rows[0]["tconst"] == "tt0000002"
+    assert provenance_count >= 2

--- a/tests/storage/test_postgres_storage.py
+++ b/tests/storage/test_postgres_storage.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from movie_recommender.storage.postgres import (
+    EmbeddingConfig,
+    SCHEMA_PATH,
+    build_ann_index_sql,
+    load_fixture,
+    render_fuzzy_title_search_sql,
+    render_vector_recommendations_sql,
+    validate_fixture_vectors,
+)
+
+
+def test_schema_defines_serving_contract_tables_and_extensions() -> None:
+    schema_sql = SCHEMA_PATH.read_text(encoding="utf-8")
+
+    for extension in ("pg_trgm", "vector"):
+        assert f"CREATE EXTENSION IF NOT EXISTS {extension};" in schema_sql
+
+    for table_name in (
+        "source_snapshots",
+        "etl_runs",
+        "etl_run_sources",
+        "row_provenance",
+        "movies",
+        "movie_external_ids",
+        "people",
+        "person_external_ids",
+        "movie_credits",
+        "movie_text_features",
+        "movie_embeddings",
+    ):
+        assert f"CREATE TABLE IF NOT EXISTS {table_name}" in schema_sql
+
+    assert "UNIQUE NULLS NOT DISTINCT" in schema_sql
+    assert "gin_trgm_ops" in schema_sql
+    assert "CHECK (vector_dims(embedding) = vector_dimension)" in schema_sql
+
+
+def test_vector_query_uses_literal_serving_slice_predicates() -> None:
+    config = EmbeddingConfig(
+        feature_name="recommendation_soup",
+        feature_version="v1",
+        model_name="local-fixture-model",
+        model_version="2026-06-12",
+        vector_dimension=3,
+    )
+
+    sql = render_vector_recommendations_sql(config)
+
+    assert "e.embedding::vector(3) <=> q.embedding" in sql
+    assert "e.model_name = 'local-fixture-model'" in sql
+    assert "e.model_version = '2026-06-12'" in sql
+    assert "e.vector_dimension = 3" in sql
+    assert "e.feature_name = 'recommendation_soup'" in sql
+    assert "e.feature_version = 'v1'" in sql
+    assert "%(query_tconst)s" in sql
+    assert "%(candidate_limit)s" in sql
+
+
+def test_ann_index_sql_scopes_to_configured_embedding_space() -> None:
+    config = EmbeddingConfig(
+        feature_name="recommendation_soup",
+        feature_version="v1",
+        model_name="local-fixture-model",
+        model_version="2026-06-12",
+        vector_dimension=3,
+    )
+
+    sql = build_ann_index_sql(config, index_name="idx_test_ann")
+
+    assert "USING hnsw ((embedding::vector(3)) vector_cosine_ops)" in sql
+    assert "WHERE active" in sql
+    assert "feature_name = 'recommendation_soup'" in sql
+    assert "model_name = 'local-fixture-model'" in sql
+    assert "vector_dimension = 3" in sql
+
+
+def test_fuzzy_title_query_uses_trigram_operators_and_stable_ordering() -> None:
+    sql = render_fuzzy_title_search_sql()
+
+    assert "similarity(display_title, %(query)s)" in sql
+    assert "display_title % %(query)s" in sql
+    assert "primary_title % %(query)s" in sql
+    assert "ORDER BY title_similarity DESC" in sql
+    assert "tconst ASC" in sql
+
+
+def test_tiny_fixture_matches_configured_vector_dimension() -> None:
+    fixture = json.loads(
+        Path("fixtures/storage/tiny_serving_fixture.json").read_text(encoding="utf-8")
+    )
+    config = EmbeddingConfig(**fixture["embedding_config"])
+
+    validate_fixture_vectors(fixture, config)
+
+
+def test_fixture_dimension_mismatch_is_rejected() -> None:
+    fixture = json.loads(
+        Path("fixtures/storage/tiny_serving_fixture.json").read_text(encoding="utf-8")
+    )
+    config = EmbeddingConfig(
+        feature_name="recommendation_soup",
+        feature_version="v1",
+        model_name="local-fixture-model",
+        model_version="2026-06-12",
+        vector_dimension=4,
+    )
+
+    with pytest.raises(ValueError, match="vector_dimension"):
+        validate_fixture_vectors(fixture, config)
+
+
+class RecordingCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, dict[str, object] | None]] = []
+        self._etl_run_id = 100
+        self._source_snapshot_id = 200
+        self._people: dict[str, int] = {}
+        self._text_features: dict[str, int] = {}
+        self._last_result: tuple[int, ...] | None = None
+
+    def execute(self, sql: str, params: dict[str, object] | None = None) -> None:
+        self.executed.append((sql, params))
+        if "RETURNING etl_run_id" in sql:
+            self._last_result = (self._etl_run_id,)
+        elif "RETURNING source_snapshot_id" in sql:
+            self._last_result = (self._source_snapshot_id,)
+        elif "RETURNING person_id" in sql:
+            key = str(params["nconst"])
+            self._people.setdefault(key, len(self._people) + 1)
+            self._last_result = (self._people[key],)
+        elif "RETURNING text_feature_id" in sql:
+            key = str(params["tconst"])
+            self._text_features.setdefault(key, len(self._text_features) + 10)
+            self._last_result = (self._text_features[key],)
+        else:
+            self._last_result = None
+
+    def fetchone(self) -> tuple[int, ...]:
+        assert self._last_result is not None
+        return self._last_result
+
+
+class RecordingConnection:
+    def __init__(self) -> None:
+        self.cursor_obj = RecordingCursor()
+        self.commits = 0
+
+    def cursor(self) -> RecordingCursor:
+        return self.cursor_obj
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+def test_load_fixture_upserts_canonical_movies_text_features_and_vectors() -> None:
+    fixture = json.loads(
+        Path("fixtures/storage/tiny_serving_fixture.json").read_text(encoding="utf-8")
+    )
+    config = EmbeddingConfig(**fixture["embedding_config"])
+    conn = RecordingConnection()
+
+    load_fixture(conn, fixture, config)
+
+    all_sql = "\n".join(sql for sql, _ in conn.cursor_obj.executed)
+    assert "INSERT INTO movies" in all_sql
+    assert "ON CONFLICT (tconst) DO UPDATE" in all_sql
+    assert "UPDATE movie_text_features" in all_sql
+    assert "active = false" in all_sql
+    assert "INSERT INTO movie_text_features" in all_sql
+    assert "ON CONFLICT (tconst, feature_name, feature_version, source_text_sha256)" in all_sql
+    assert "INSERT INTO movie_embeddings" in all_sql
+    assert "ON CONFLICT (text_feature_id, model_name, model_version, vector_dimension)" in all_sql
+    assert "INSERT INTO row_provenance" in all_sql
+    assert conn.commits == 1

--- a/tests/storage/test_postgres_storage.py
+++ b/tests/storage/test_postgres_storage.py
@@ -81,12 +81,40 @@ def test_ann_index_sql_scopes_to_configured_embedding_space() -> None:
     assert "vector_dimension = 3" in sql
 
 
+def test_ann_index_default_name_is_derived_from_embedding_config() -> None:
+    first_config = EmbeddingConfig(
+        feature_name="recommendation_soup",
+        feature_version="v1",
+        model_name="local-fixture-model",
+        model_version="2026-06-12",
+        vector_dimension=3,
+    )
+    second_config = EmbeddingConfig(
+        feature_name="recommendation_soup",
+        feature_version="v1",
+        model_name="local-fixture-model",
+        model_version="2026-06-13",
+        vector_dimension=4,
+    )
+
+    first_sql = build_ann_index_sql(first_config)
+    second_sql = build_ann_index_sql(second_config)
+    first_index_name = first_sql.split()[5]
+    second_index_name = second_sql.split()[5]
+
+    assert first_index_name != second_index_name
+    assert first_index_name.startswith("idx_movie_emb_ann_recommendation_so")
+    assert second_index_name.startswith("idx_movie_emb_ann_recommendation_so")
+    assert len(first_index_name) <= 63
+    assert len(second_index_name) <= 63
+
+
 def test_fuzzy_title_query_uses_trigram_operators_and_stable_ordering() -> None:
     sql = render_fuzzy_title_search_sql()
 
     assert "similarity(display_title, %(query)s)" in sql
-    assert "display_title % %(query)s" in sql
-    assert "primary_title % %(query)s" in sql
+    assert "display_title %% %(query)s" in sql
+    assert "primary_title %% %(query)s" in sql
     assert "ORDER BY title_similarity DESC" in sql
     assert "tconst ASC" in sql
 
@@ -172,6 +200,8 @@ def test_load_fixture_upserts_canonical_movies_text_features_and_vectors() -> No
     assert "INSERT INTO movies" in all_sql
     assert "ON CONFLICT (tconst) DO UPDATE" in all_sql
     assert "UPDATE movie_text_features" in all_sql
+    assert "UPDATE movie_embeddings" in all_sql
+    assert "movie_embeddings.text_feature_id = movie_text_features.text_feature_id" in all_sql
     assert "active = false" in all_sql
     assert "INSERT INTO movie_text_features" in all_sql
     assert "ON CONFLICT (tconst, feature_name, feature_version, source_text_sha256)" in all_sql

--- a/tests/storage/test_postgres_storage.py
+++ b/tests/storage/test_postgres_storage.py
@@ -96,6 +96,20 @@ def test_ann_index_rejects_dimensions_above_pgvector_hnsw_limit() -> None:
         build_ann_index_sql(config)
 
 
+def test_ann_index_rejects_oversized_custom_index_names() -> None:
+    config = EmbeddingConfig(
+        feature_name="recommendation_soup",
+        feature_version="v1",
+        model_name="local-fixture-model",
+        model_version="2026-06-12",
+        vector_dimension=3,
+    )
+    index_name = "idx_" + ("a" * 64)
+
+    with pytest.raises(ValueError, match="63"):
+        build_ann_index_sql(config, index_name=index_name)
+
+
 def test_ann_index_default_name_is_derived_from_embedding_config() -> None:
     first_config = EmbeddingConfig(
         feature_name="recommendation_soup",
@@ -263,6 +277,8 @@ def test_load_fixture_upserts_canonical_movies_text_features_and_vectors() -> No
     assert "active = false" in all_sql
     assert "DELETE FROM movie_credits" in all_sql
     assert "INSERT INTO movie_text_features" in all_sql
+    assert "WHERE movie_credits.source_name = 'tiny_fixture'" in all_sql
+    assert "source_name = EXCLUDED.source_name" not in all_sql
     assert "ON CONFLICT (tconst, feature_name, feature_version, source_text_sha256)" in all_sql
     assert "INSERT INTO movie_embeddings" in all_sql
     assert "ON CONFLICT (text_feature_id, model_name, model_version, vector_dimension)" in all_sql

--- a/tests/storage/test_postgres_storage.py
+++ b/tests/storage/test_postgres_storage.py
@@ -38,8 +38,15 @@ def test_schema_defines_serving_contract_tables_and_extensions() -> None:
         assert f"CREATE TABLE IF NOT EXISTS {table_name}" in schema_sql
 
     assert "UNIQUE NULLS NOT DISTINCT" in schema_sql
+    assert "UNIQUE (tconst, person_id, role_type, credit_order, source_name)" in schema_sql
     assert "gin_trgm_ops" in schema_sql
     assert "CHECK (vector_dims(embedding) = vector_dimension)" in schema_sql
+
+
+def test_docker_compose_binds_postgres_to_localhost() -> None:
+    compose_yaml = Path("docker-compose.yml").read_text(encoding="utf-8")
+
+    assert '"127.0.0.1:54329:5432"' in compose_yaml
 
 
 def test_vector_query_uses_literal_serving_slice_predicates() -> None:
@@ -271,6 +278,7 @@ def test_load_fixture_upserts_canonical_movies_text_features_and_vectors() -> No
     assert "end_year = EXCLUDED.end_year" in all_sql
     assert "UPDATE movies" in all_sql
     assert "tconst <> ALL(%(active_tconsts)s::text[])" in all_sql
+    assert "last_seen_etl_run_id = %(etl_run_id)s" not in all_sql
     assert "UPDATE movie_text_features" in all_sql
     assert "UPDATE movie_embeddings" in all_sql
     assert "movie_embeddings.text_feature_id = movie_text_features.text_feature_id" in all_sql
@@ -279,6 +287,7 @@ def test_load_fixture_upserts_canonical_movies_text_features_and_vectors() -> No
     assert "INSERT INTO movie_text_features" in all_sql
     assert "WHERE movie_credits.source_name = 'tiny_fixture'" in all_sql
     assert "source_name = EXCLUDED.source_name" not in all_sql
+    assert "ON CONFLICT (tconst, person_id, role_type, credit_order, source_name)" in all_sql
     assert "ON CONFLICT (tconst, feature_name, feature_version, source_text_sha256)" in all_sql
     assert "INSERT INTO movie_embeddings" in all_sql
     assert "ON CONFLICT (text_feature_id, model_name, model_version, vector_dimension)" in all_sql

--- a/tests/storage/test_postgres_storage.py
+++ b/tests/storage/test_postgres_storage.py
@@ -59,6 +59,8 @@ def test_vector_query_uses_literal_serving_slice_predicates() -> None:
     assert "e.vector_dimension = 3" in sql
     assert "e.feature_name = 'recommendation_soup'" in sql
     assert "e.feature_version = 'v1'" in sql
+    assert "JOIN movies qm ON qm.tconst = e.tconst" in sql
+    assert "qm.active" in sql
     assert "%(query_tconst)s" in sql
     assert "%(candidate_limit)s" in sql
 
@@ -79,6 +81,19 @@ def test_ann_index_sql_scopes_to_configured_embedding_space() -> None:
     assert "feature_name = 'recommendation_soup'" in sql
     assert "model_name = 'local-fixture-model'" in sql
     assert "vector_dimension = 3" in sql
+
+
+def test_ann_index_rejects_dimensions_above_pgvector_hnsw_limit() -> None:
+    config = EmbeddingConfig(
+        feature_name="recommendation_soup",
+        feature_version="v1",
+        model_name="large-model",
+        model_version="v1",
+        vector_dimension=3072,
+    )
+
+    with pytest.raises(ValueError, match="HNSW"):
+        build_ann_index_sql(config)
 
 
 def test_ann_index_default_name_is_derived_from_embedding_config() -> None:
@@ -103,10 +118,25 @@ def test_ann_index_default_name_is_derived_from_embedding_config() -> None:
     second_index_name = second_sql.split()[5]
 
     assert first_index_name != second_index_name
-    assert first_index_name.startswith("idx_movie_emb_ann_recommendation_so")
-    assert second_index_name.startswith("idx_movie_emb_ann_recommendation_so")
+    assert first_index_name.startswith("idx_movie_emb_ann_recommendation_s")
+    assert second_index_name.startswith("idx_movie_emb_ann_recommendation_s")
     assert len(first_index_name) <= 63
     assert len(second_index_name) <= 63
+
+
+def test_ann_index_default_name_stays_under_postgres_identifier_limit() -> None:
+    config = EmbeddingConfig(
+        feature_name="feature_name_hits_max",
+        feature_version="version_max",
+        model_name="model-name-with-extra-characters",
+        model_version="model-version-with-extra-characters",
+        vector_dimension=2000,
+    )
+
+    sql = build_ann_index_sql(config)
+    index_name = sql.split()[5]
+
+    assert len(index_name) <= 63
 
 
 def test_fuzzy_title_query_uses_trigram_operators_and_stable_ordering() -> None:
@@ -199,6 +229,8 @@ def test_load_fixture_upserts_canonical_movies_text_features_and_vectors() -> No
     all_sql = "\n".join(sql for sql, _ in conn.cursor_obj.executed)
     assert "INSERT INTO movies" in all_sql
     assert "ON CONFLICT (tconst) DO UPDATE" in all_sql
+    assert "end_year" in all_sql
+    assert "end_year = EXCLUDED.end_year" in all_sql
     assert "UPDATE movie_text_features" in all_sql
     assert "UPDATE movie_embeddings" in all_sql
     assert "movie_embeddings.text_feature_id = movie_text_features.text_feature_id" in all_sql

--- a/tests/storage/test_postgres_storage.py
+++ b/tests/storage/test_postgres_storage.py
@@ -139,6 +139,30 @@ def test_ann_index_default_name_stays_under_postgres_identifier_limit() -> None:
     assert len(index_name) <= 63
 
 
+def test_ann_index_default_name_stays_under_postgres_byte_limit() -> None:
+    first_config = EmbeddingConfig(
+        feature_name="é" * 16,
+        feature_version="versión",
+        model_name="modelo-con-acentos",
+        model_version="versión-uno",
+        vector_dimension=2000,
+    )
+    second_config = EmbeddingConfig(
+        feature_name="é" * 16,
+        feature_version="versión",
+        model_name="modelo-con-acentos",
+        model_version="versión-dos",
+        vector_dimension=2000,
+    )
+
+    first_index_name = build_ann_index_sql(first_config).split()[5]
+    second_index_name = build_ann_index_sql(second_config).split()[5]
+
+    assert len(first_index_name.encode("utf-8")) <= 63
+    assert len(second_index_name.encode("utf-8")) <= 63
+    assert first_index_name != second_index_name
+
+
 def test_fuzzy_title_query_uses_trigram_operators_and_stable_ordering() -> None:
     sql = render_fuzzy_title_search_sql()
 
@@ -231,10 +255,13 @@ def test_load_fixture_upserts_canonical_movies_text_features_and_vectors() -> No
     assert "ON CONFLICT (tconst) DO UPDATE" in all_sql
     assert "end_year" in all_sql
     assert "end_year = EXCLUDED.end_year" in all_sql
+    assert "UPDATE movies" in all_sql
+    assert "tconst <> ALL(%(active_tconsts)s::text[])" in all_sql
     assert "UPDATE movie_text_features" in all_sql
     assert "UPDATE movie_embeddings" in all_sql
     assert "movie_embeddings.text_feature_id = movie_text_features.text_feature_id" in all_sql
     assert "active = false" in all_sql
+    assert "DELETE FROM movie_credits" in all_sql
     assert "INSERT INTO movie_text_features" in all_sql
     assert "ON CONFLICT (tconst, feature_name, feature_version, source_text_sha256)" in all_sql
     assert "INSERT INTO movie_embeddings" in all_sql


### PR DESCRIPTION
## Summary
- Adds a provider-neutral Postgres/pgvector serving schema from the #40 design contract.
- Adds `DATABASE_URL`-driven schema apply, tiny fixture load, and query verification commands.
- Adds storage helpers for fuzzy title search, vector retrieval, scoped ANN index SQL, and tiny fixture loading/upserts.
- Adds offline tests for schema/query rendering/fixture loading plus an optional `POSTGRES_TEST_DSN` integration test.
- Updates docs to treat managed Postgres providers such as Neon as the preferred target and local Docker as optional convenience only.

Refs #16

## Current status

Draft candidate only. Development is paused while we rethink the product direction, and #16 has been moved back to Roadmap. Do not merge this PR as-is.

Known issue before any future merge: logical credits currently need a final dedupe/provenance pass so the serving table cannot duplicate the same credit across IMDb/TMDB-like sources.

## Verification

Latest watchdog verification before the docs-only update:

```bash
make test
# 56 passed, 1 skipped in 7.01s

make smoke
# System check identified no issues (0 silenced).
```

Docs-only update verification:

```bash
git diff --check
# no output
```

Live local Docker/Postgres verification is not expected from the Juno VPS because the `juno` user intentionally does not have Docker socket access. Future DB verification should target a managed Postgres/pgvector database via `DATABASE_URL` or CI-provided Postgres, not host Docker access.